### PR TITLE
fix: full GitHub OAuth2 login flow

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Fixed
 - **OAuth2 provider configuration**: added `authorization_endpoint`, `token_endpoint`, and `userinfo_endpoint` fields to provider create/update schemas so non-OIDC OAuth2 providers (e.g. GitHub) can be fully configured without relying on OIDC discovery
 - **OIDC discovery guard**: discover endpoint now returns a clear 400 error for `oauth2`-type providers instead of attempting `.well-known/openid-configuration` lookup (which always 404s for pure OAuth2 providers)
+- **GitHub token exchange**: `exchange_code()` now sends `Accept: application/json` header and handles form-encoded responses (GitHub returns `application/x-www-form-urlencoded` by default)
+- **OAuth2 userinfo normalisation**: `fetch_userinfo()` maps non-standard claim names to OIDC equivalents (`id` → `sub`, `login` → `preferred_username`) so downstream identity extraction works for GitHub and similar OAuth2 providers
+- **GitHub private email fallback**: when GitHub's `/user` endpoint returns `email: null` (user has private email), the service fetches the primary verified email from `/user/emails`
 
 ## 0.8.1 - 2026-02-07
 ### Added

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - **OAuth2 provider form**: endpoint URL fields (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`) now shown in provider form — required for OAuth2, optional for OIDC
 - **GitHub OAuth2 preset**: "Quick fill" button auto-populates GitHub's OAuth2 endpoint URLs when creating a GitHub provider
 - **Discover button hidden for OAuth2**: the "Discover" action is no longer shown for `oauth2`-type providers since they don't support OIDC discovery
+- **PKCE skipped for OAuth2**: login flow no longer sends `code_challenge`/`code_challenge_method` for `oauth2`-type providers (GitHub OAuth Apps don't support PKCE)
+- **Scope defaults**: OAuth2 providers default to `read:user user:email` instead of `openid profile email` when no scope is configured
 
 ## 0.8.1 - 2026-02-07
 ### Added


### PR DESCRIPTION
## Summary
End-to-end fix for GitHub OAuth2 login. Five distinct issues prevented the flow from working:

- **redirect_uri mismatch** — GitHub OAuth App callback URL must be set to `https://grapheon.badgerops.foo/login` (config-side fix, not in this PR)
- **PKCE not supported** — GitHub OAuth Apps reject `code_challenge`; frontend now only sends PKCE params for `oidc`-type providers
- **Wrong scopes** — was sending `openid profile email` (OIDC scopes); OAuth2 providers now default to `read:user user:email`
- **Token response format** — GitHub returns `application/x-www-form-urlencoded` by default; `exchange_code()` now sends `Accept: application/json` and handles form-encoded fallback
- **Non-standard userinfo claims** — GitHub's `/user` returns `id`/`login` instead of `sub`/`preferred_username`; `fetch_userinfo()` now normalises these, plus fetches `/user/emails` when email is private

### Backend (`oidc_service.py`, `routers/auth.py`)
- `exchange_code()`: `Accept: application/json` header + form-encoded response parsing
- `fetch_userinfo()`: claim normalisation (`id`→`sub`, `login`→`preferred_username`) + GitHub private email fallback via `/user/emails`
- Provider create/update schemas accept `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`
- Discover endpoint rejects `oauth2` providers with helpful 400 error

### Frontend (`Login.jsx`, `AuthAdmin.jsx`)
- PKCE only for OIDC; skipped for OAuth2
- Scope defaults: `read:user user:email` for OAuth2, `openid profile email` for OIDC
- Provider form shows endpoint URL fields (required for OAuth2, optional for OIDC)
- GitHub quick-fill preset for endpoint URLs
- Discover button hidden for oauth2-type providers

### Also
- Pre-commit hook: `ruff` falls back to `python -m ruff` when bare command is missing
- Version bump to **0.8.2**

## Required config change
After deploying, set the GitHub OAuth App's **Authorization callback URL** to:
```
https://grapheon.badgerops.foo/login
```

## Test plan
- [x] All 330 backend tests pass (46 auth)
- [x] Ruff lint clean
- [x] Frontend builds
- [x] Version sync validated
- [ ] Set GitHub OAuth callback URL to `https://grapheon.badgerops.foo/login`
- [ ] Create GitHub OAuth2 provider via admin UI with quick-fill preset
- [ ] Complete full GitHub OAuth2 login flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)