### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release Images
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 concurrency:
   group: release


### PR DESCRIPTION
Allows manually re-running the release workflow from the GitHub Actions UI when needed (e.g., after deleting a stale tag).

https://claude.ai/code/session_014h1gsEA8tArGGL7RvVDz4e