### PR TITLE
Phase 0 hardening for imports, auth, and task scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export LOCAL_ADMIN_PASSWORD=changeme
 export JWT_SECRET=$(openssl rand -hex 32)
 ```
 
-The admin user is created automatically on first startup. Auth is enabled by default but not enforced (`ENFORCE_AUTH=False`), so existing deployments continue to work without interruption.
+The admin user is created automatically on first startup. Auth is enabled by default but not fully enforced (`ENFORCE_AUTH=False`): read-only endpoints remain accessible without login, but write/admin actions require authentication.
 
 Set `ENFORCE_AUTH=True` when ready to require login for all users.
 

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -176,12 +176,18 @@ def require_role(*allowed_roles: str):
 
         # When auth is enabled but not enforced, be permissive
         if not settings.ENFORCE_AUTH and not credentials:
-            return User(
-                id=0,
-                username="anonymous",
-                email="anon@localhost",
-                role="admin",
-                is_active=True,
+            if "viewer" in allowed_roles:
+                return User(
+                    id=0,
+                    username="anonymous-viewer",
+                    email="anon-viewer@localhost",
+                    role="viewer",
+                    is_active=True,
+                )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required for write access",
+                headers={"WWW-Authenticate": "Bearer"},
             )
 
         # Full auth check

--- a/backend/database.py
+++ b/backend/database.py
@@ -105,6 +105,7 @@ def _run_migrations(sync_conn) -> None:
         "raw_imports",
         [
             ("source_host", "source_host VARCHAR(255)"),
+            ("stored_file_path", "stored_file_path VARCHAR(1024)"),
         ],
     )
 
@@ -119,6 +120,7 @@ def _run_migrations(sync_conn) -> None:
 
     # Migrate connections table: make remote_port nullable (for LISTEN state)
     _make_column_nullable(sync_conn, "connections", "remote_port")
+    _make_column_nullable(sync_conn, "raw_imports", "raw_data")
 
 
 def _ensure_columns(sync_conn, table: str, columns: list[tuple[str, str]]) -> None:

--- a/backend/models/raw_import.py
+++ b/backend/models/raw_import.py
@@ -18,7 +18,8 @@ class RawImport(Base):
     source_host = Column(String(255), nullable=True)
 
     # Raw data
-    raw_data = Column(Text, nullable=False)
+    raw_data = Column(Text, nullable=True)
+    stored_file_path = Column(String(1024), nullable=True)
 
     # Parse results
     parse_status = Column(String(50), default="pending")  # pending/success/failed/partial

--- a/backend/parsers/pcap.py
+++ b/backend/parsers/pcap.py
@@ -11,7 +11,9 @@ Requires: scapy (pip install scapy)
 """
 
 import importlib.util
+import io
 import logging
+import os
 from datetime import datetime
 from typing import Optional, Dict, Set, Tuple
 from collections import defaultdict
@@ -97,14 +99,12 @@ class PcapParser(BaseParser):
 
         return None
 
-    def parse(self, data: str, format_hint: Optional[str] = None) -> ParseResult:
+    def parse(self, data: str | bytes, format_hint: Optional[str] = None) -> ParseResult:
         """
         Parse PCAP data and extract connection flows.
 
-        Note: This method expects a file path, not raw data, due to binary nature of PCAP.
-
         Args:
-            data: Path to PCAP file
+            data: Path to PCAP file, tcpdump text, or raw PCAP bytes
             format_hint: Optional format hint
 
         Returns:
@@ -131,9 +131,14 @@ class PcapParser(BaseParser):
         try:
             from scapy.all import rdpcap, IP, IPv6, TCP, UDP, ICMP
 
-            # Read packets
+            # Read packets from path or in-memory bytes.
             logger.info("Loading PCAP file with scapy...")
-            packets = rdpcap(data)
+            if isinstance(data, (bytes, bytearray)):
+                packets = rdpcap(io.BytesIO(data))
+            elif isinstance(data, str) and os.path.exists(data):
+                packets = rdpcap(data)
+            else:
+                return self._parse_tcpdump_text(str(data), result)
             logger.info(f"Loaded {len(packets)} packets")
 
             # Track flows

--- a/backend/routers/correlation.py
+++ b/backend/routers/correlation.py
@@ -101,6 +101,7 @@ async def run_correlation(
         task_id = task_queue.submit(
             "correlation",
             _run_correlation_background,
+            owner_user_id=user.id,
         )
 
         return {

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -15,6 +15,7 @@ from auth.dependencies import require_any_authenticated, require_editor
 from schemas import RawImportResponse, PaginatedResponse
 from parsers import get_parser, PARSERS
 from config import settings
+from services.file_validator import MAX_FILE_SIZE_BYTES, validate_upload
 from services.task_queue import task_queue
 from utils.tagging import (
     build_host_tags,
@@ -54,16 +55,8 @@ def _save_upload_to_disk(filename: Optional[str], content: bytes) -> Optional[st
 
     Returns the saved file path, or None if save was skipped.
     """
-    from services.file_validator import validate_upload
-
-    validation = validate_upload(filename, content)
-    if validation.warnings:
-        logger.info(f"Upload validation warnings for {filename}: {validation.warnings}")
-
     upload_dir = Path(settings.UPLOAD_DIR)
-    if not upload_dir.exists():
-        logger.warning(f"Upload directory does not exist: {upload_dir}, skipping disk save")
-        return None
+    upload_dir.mkdir(parents=True, exist_ok=True)
 
     # UUID prefix avoids filename collisions
     safe_filename = f"{uuid.uuid4().hex[:8]}_{filename or 'upload.dat'}"
@@ -71,6 +64,25 @@ def _save_upload_to_disk(filename: Optional[str], content: bytes) -> Optional[st
     disk_path.write_bytes(content)
     logger.info(f"Saved upload to disk: {disk_path}")
     return str(disk_path)
+
+
+def _validate_uploaded_content(filename: Optional[str], content: bytes) -> None:
+    validation = validate_upload(filename, content)
+    if validation.warnings:
+        logger.info(f"Upload validation warnings for {filename}: {validation.warnings}")
+    if validation.errors:
+        detail = "; ".join(validation.errors)
+        status_code = 413 if len(content) > MAX_FILE_SIZE_BYTES else 400
+        raise HTTPException(status_code=status_code, detail=detail)
+
+
+def _decode_upload_content(source_type: str, content: bytes) -> Optional[str]:
+    if source_type == "pcap":
+        return None
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content.decode("latin-1")
 
 
 async def _upsert_host_from_value(
@@ -150,7 +162,7 @@ async def _process_import(
     db: AsyncSession,
     import_record: RawImport,
     source_type: str,
-    raw_data: str,
+    parse_input: str | bytes,
 ) -> None:
     """Parse raw data and create database records."""
 
@@ -163,7 +175,7 @@ async def _process_import(
     try:
         logger.debug(f"Getting parser for source_type={source_type}")
         parser = get_parser(source_type)
-        result = parser.parse(raw_data)
+        result = parser.parse(parse_input)
         logger.debug(f"Parse result: success={result.success}, hosts={len(result.hosts)}, errors={result.errors}")
 
         if not result.success:
@@ -420,7 +432,12 @@ async def _process_import(
         import_record.error_message = str(e)
 
 
-async def _run_import_background(import_id: int, source_type: str, raw_data: str, source_host: Optional[str], filename: Optional[str]) -> dict:
+async def _run_import_background(
+    import_id: int,
+    source_type: str,
+    source_host: Optional[str],
+    filename: Optional[str],
+) -> dict:
     """
     Execute import processing in a background task with its own DB session.
 
@@ -434,7 +451,10 @@ async def _run_import_background(import_id: int, source_type: str, raw_data: str
 
         if source_host:
             await _upsert_host_from_value(db, source_host, "import_source")
-        await _process_import(db, import_record, source_type, raw_data)
+        parse_input = import_record.stored_file_path if source_type == "pcap" else import_record.raw_data
+        if parse_input is None:
+            raise ValueError(f"Import record {import_id} has no input payload")
+        await _process_import(db, import_record, source_type, parse_input)
 
         await db.commit()
         await db.refresh(import_record)
@@ -506,7 +526,7 @@ async def import_raw_data(
 
     if sync:
         # Synchronous mode: process inline and return full result
-        await _run_import_background(import_id, source_type, raw_data, source_host, filename)
+        await _run_import_background(import_id, source_type, source_host, filename)
         async with AsyncSessionLocal() as db2:
             result = await db2.execute(select(RawImport).where(RawImport.id == import_id))
             refreshed = result.scalar_one()
@@ -515,7 +535,8 @@ async def import_raw_data(
     # Async mode: enqueue and return task ID immediately
     task_id = task_queue.submit(
         "import",
-        lambda _id=import_id, _st=source_type, _rd=raw_data, _sh=source_host, _fn=filename: _run_import_background(_id, _st, _rd, _sh, _fn),
+        lambda _id=import_id, _st=source_type, _sh=source_host, _fn=filename: _run_import_background(_id, _st, _sh, _fn),
+        owner_user_id=user.id,
     )
 
     return {
@@ -550,10 +571,12 @@ async def import_file(
     # Read file content
     try:
         content = await file.read()
-        # Save to disk for audit trail
-        _save_upload_to_disk(file.filename, content)
-        raw_data = content.decode("utf-8")
+        _validate_uploaded_content(file.filename, content)
+        stored_file_path = _save_upload_to_disk(file.filename, content)
+        raw_data = _decode_upload_content(source_type, content)
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise
         raise HTTPException(
             status_code=400, detail=f"Failed to read file: {str(e)}"
         )
@@ -570,6 +593,7 @@ async def import_file(
         filename=file.filename,
         source_host=source_host,
         raw_data=raw_data,
+        stored_file_path=stored_file_path,
         tags=parsed_tags,
         notes=notes or (f"Source host: {source_host}" if source_host else None),
         parse_status="pending",
@@ -583,7 +607,7 @@ async def import_file(
     await db.commit()
 
     if sync:
-        await _run_import_background(import_id, source_type, raw_data, source_host, file_filename)
+        await _run_import_background(import_id, source_type, source_host, file_filename)
         async with AsyncSessionLocal() as db2:
             result = await db2.execute(select(RawImport).where(RawImport.id == import_id))
             refreshed = result.scalar_one()
@@ -591,7 +615,8 @@ async def import_file(
 
     task_id = task_queue.submit(
         "import",
-        lambda _id=import_id, _st=source_type, _rd=raw_data, _sh=source_host, _fn=file_filename: _run_import_background(_id, _st, _rd, _sh, _fn),
+        lambda _id=import_id, _st=source_type, _sh=source_host, _fn=file_filename: _run_import_background(_id, _st, _sh, _fn),
+        owner_user_id=user.id,
     )
 
     return {
@@ -698,7 +723,12 @@ async def reparse_import(import_id: int, user: User = Depends(require_editor), d
     return RawImportResponse.model_validate(import_record)
 
 
-async def _run_bulk_import_background(import_ids: list[int], source_type: str, file_data: list[dict], source_host: Optional[str]) -> dict:
+async def _run_bulk_import_background(
+    import_ids: list[int],
+    source_type: str,
+    filenames: list[str],
+    source_host: Optional[str],
+) -> dict:
     """
     Execute bulk import processing in a background task with its own DB session.
     """
@@ -713,7 +743,7 @@ async def _run_bulk_import_background(import_ids: list[int], source_type: str, f
         "errors": [],
     }
 
-    for i, (import_id, fdata) in enumerate(zip(import_ids, file_data)):
+    for i, (import_id, filename) in enumerate(zip(import_ids, filenames)):
         file_start = time.perf_counter()
         try:
             async with AsyncSessionLocal() as db:
@@ -724,13 +754,16 @@ async def _run_bulk_import_background(import_ids: list[int], source_type: str, f
 
                 if source_host:
                     await _upsert_host_from_value(db, source_host, "import_source")
-                await _process_import(db, import_record, source_type, fdata["raw_data"])
+                parse_input = import_record.stored_file_path if source_type == "pcap" else import_record.raw_data
+                if parse_input is None:
+                    raise ValueError(f"Import record {import_id} has no input payload")
+                await _process_import(db, import_record, source_type, parse_input)
                 await db.commit()
                 await db.refresh(import_record)
 
                 file_duration = (time.perf_counter() - file_start) * 1000
                 logger.info(
-                    f"[{i+1}/{len(import_ids)}] {fdata['filename']}: "
+                    f"[{i+1}/{len(import_ids)}] {filename}: "
                     f"status={import_record.parse_status}, "
                     f"records={import_record.parsed_count}, "
                     f"duration={file_duration:.1f}ms"
@@ -738,7 +771,7 @@ async def _run_bulk_import_background(import_ids: list[int], source_type: str, f
 
                 results["imports"].append({
                     "id": import_record.id,
-                    "filename": fdata["filename"],
+                    "filename": filename,
                     "status": import_record.parse_status,
                     "parsed_count": import_record.parsed_count,
                     "error": import_record.error_message,
@@ -750,8 +783,8 @@ async def _run_bulk_import_background(import_ids: list[int], source_type: str, f
                     results["failed"] += 1
 
         except Exception as e:
-            logger.error(f"[{i+1}/{len(import_ids)}] {fdata['filename']}: Error - {e}")
-            results["errors"].append({"filename": fdata["filename"], "error": str(e)})
+            logger.error(f"[{i+1}/{len(import_ids)}] {filename}: Error - {e}")
+            results["errors"].append({"filename": filename, "error": str(e)})
             results["failed"] += 1
 
     total_duration = (time.perf_counter() - start_time) * 1000
@@ -804,16 +837,14 @@ async def bulk_import_files(
 
     # Read all files and create import records up front
     import_ids = []
-    file_data = []
+    filenames = []
 
     for file in files:
         try:
             content = await file.read()
-            _save_upload_to_disk(file.filename, content)
-            try:
-                raw_data = content.decode("utf-8")
-            except UnicodeDecodeError:
-                raw_data = content.decode("latin-1")
+            _validate_uploaded_content(file.filename, content)
+            stored_file_path = _save_upload_to_disk(file.filename, content)
+            raw_data = _decode_upload_content(source_type, content)
 
             import_record = RawImport(
                 source_type=source_type,
@@ -821,6 +852,7 @@ async def bulk_import_files(
                 filename=file.filename,
                 source_host=source_host,
                 raw_data=raw_data,
+                stored_file_path=stored_file_path,
                 tags=parsed_tags,
                 notes=notes or (f"Source host: {source_host}" if source_host else None),
                 parse_status="pending",
@@ -829,7 +861,7 @@ async def bulk_import_files(
             db.add(import_record)
             await db.flush()
             import_ids.append(import_record.id)
-            file_data.append({"filename": file.filename, "raw_data": raw_data})
+            filenames.append(file.filename or f"import-{import_record.id}")
         except Exception as e:
             logger.error(f"Failed to read file {file.filename}: {e}")
             # Still try other files
@@ -837,11 +869,12 @@ async def bulk_import_files(
     await db.commit()
 
     if sync:
-        return await _run_bulk_import_background(import_ids, source_type, file_data, source_host)
+        return await _run_bulk_import_background(import_ids, source_type, filenames, source_host)
 
     task_id = task_queue.submit(
         "import",
-        lambda _ids=import_ids, _st=source_type, _fd=file_data, _sh=source_host: _run_bulk_import_background(_ids, _st, _fd, _sh),
+        lambda _ids=import_ids, _st=source_type, _files=filenames, _sh=source_host: _run_bulk_import_background(_ids, _st, _files, _sh),
+        owner_user_id=user.id,
     )
 
     return {

--- a/backend/routers/maintenance.py
+++ b/backend/routers/maintenance.py
@@ -344,7 +344,11 @@ async def create_backup(user: User = Depends(require_admin), db: AsyncSession = 
     # Get backup file size
     backup_size = os.path.getsize(backup_path)
 
-    audit.log_backup_restore(operation="backup", filename=backup_filename)
+    audit.log_backup_restore(
+        operation="backup",
+        filename=backup_filename,
+        status="success",
+    )
 
     # ── Retention policy ────────────────────────────────────────────
     pruned = _enforce_retention(backup_dir)
@@ -643,7 +647,11 @@ async def restore_backup(filename: str, user: User = Depends(require_admin)):
         logger.error(f"Restore failed: {e}")
         raise HTTPException(status_code=500, detail=f"Restore failed: {str(e)}")
 
-    audit.log_backup_restore(operation="restore", filename=filename)
+    audit.log_backup_restore(
+        operation="restore",
+        filename=filename,
+        status="success",
+    )
 
     return {
         "success": True,
@@ -732,7 +740,11 @@ async def upload_backup(file: UploadFile = File(...), user: User = Depends(requi
 
     file_size = os.path.getsize(dest_path)
 
-    audit.log_backup_restore(operation="upload", filename=safe_filename)
+    audit.log_backup_restore(
+        operation="upload",
+        filename=safe_filename,
+        status="success",
+    )
 
     return {
         "success": True,

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -27,7 +27,11 @@ async def get_task_status(
 
     Returns task state, progress, result (if complete), or error (if failed).
     """
-    task = task_queue.get_task(task_id)
+    task = task_queue.get_task(
+        task_id,
+        owner_user_id=user.id,
+        include_all=user.role == "admin",
+    )
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return task.to_dict()
@@ -52,7 +56,13 @@ async def list_tasks(
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
 
-    tasks = task_queue.list_tasks(task_type=task_type, status=status_filter, limit=limit)
+    tasks = task_queue.list_tasks(
+        task_type=task_type,
+        status=status_filter,
+        limit=limit,
+        owner_user_id=user.id,
+        include_all=user.role == "admin",
+    )
     return {
         "total": len(tasks),
         "items": [t.to_dict() for t in tasks],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -537,7 +537,7 @@ class RawImportFields(BaseModel):
     import_type: str
     filename: Optional[str] = Field(None, max_length=500)
     source_host: Optional[str] = None
-    raw_data: str
+    raw_data: Optional[str] = None
     tags: Optional[List[str]] = None
     notes: Optional[str] = Field(None, max_length=5000)
 

--- a/backend/services/file_validator.py
+++ b/backend/services/file_validator.py
@@ -7,7 +7,8 @@ NOTE/TODO: Future enhancements planned:
   should start with <?xml or <!-- Nmap)
 - Enforce organization-specific file type policies
 
-Currently this module logs validation warnings but does NOT reject files.
+Currently this module returns validation warnings and errors. Callers decide
+whether to reject uploads based on ``errors``.
 """
 
 import logging
@@ -49,7 +50,7 @@ class FileValidationResult:
 def check_file_size(content_length: int) -> Optional[str]:
     """Check if file size is within allowed limits.
 
-    Returns warning message if oversized, None if OK.
+    Returns an error message if oversized, None if OK.
     """
     if content_length > MAX_FILE_SIZE_BYTES:
         return (
@@ -113,10 +114,10 @@ def validate_upload(
     result = FileValidationResult()
 
     # Size check
-    size_warning = check_file_size(len(content))
-    if size_warning:
-        result.warnings.append(size_warning)
-        logger.warning(f"File validation: {size_warning}")
+    size_error = check_file_size(len(content))
+    if size_error:
+        result.errors.append(size_error)
+        logger.warning(f"File validation: {size_error}")
 
     # Extension check
     ext_warning = check_file_extension(filename)

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -35,6 +35,7 @@ class TaskStatus(str, Enum):
 class TaskInfo:
     id: str
     task_type: str  # "import", "correlation", "cleanup"
+    owner_user_id: Optional[int] = None
     status: TaskStatus = TaskStatus.PENDING
     progress: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
@@ -109,6 +110,7 @@ class TaskQueue:
         self,
         task_type: str,
         coro_factory: Callable[[], Coroutine],
+        owner_user_id: Optional[int] = None,
     ) -> str:
         """
         Enqueue a task and return its ID immediately.
@@ -118,22 +120,42 @@ class TaskQueue:
         creating the coroutine before it can be awaited.
         """
         task_id = str(uuid.uuid4())
-        self._tasks[task_id] = TaskInfo(id=task_id, task_type=task_type)
+        self._tasks[task_id] = TaskInfo(
+            id=task_id,
+            task_type=task_type,
+            owner_user_id=owner_user_id,
+        )
         self._ensure_worker(task_type)
         self._queues[task_type].put_nowait((task_id, coro_factory))
         logger.info(f"Task {task_id} ({task_type}) enqueued")
         return task_id
 
-    def get_task(self, task_id: str) -> Optional[TaskInfo]:
-        return self._tasks.get(task_id)
+    def get_task(
+        self,
+        task_id: str,
+        owner_user_id: Optional[int] = None,
+        include_all: bool = False,
+    ) -> Optional[TaskInfo]:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        if include_all or owner_user_id is None:
+            return task
+        if task.owner_user_id == owner_user_id:
+            return task
+        return None
 
     def list_tasks(
         self,
         task_type: Optional[str] = None,
         status: Optional[TaskStatus] = None,
         limit: int = 50,
+        owner_user_id: Optional[int] = None,
+        include_all: bool = False,
     ) -> list[TaskInfo]:
         tasks = list(self._tasks.values())
+        if not include_all and owner_user_id is not None:
+            tasks = [t for t in tasks if t.owner_user_id == owner_user_id]
         if task_type:
             tasks = [t for t in tasks if t.task_type == task_type]
         if status:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,13 +7,17 @@ Provides:
 - AsyncClient for testing async endpoints
 """
 
+import uuid
+
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
+from auth.jwt_service import create_access_token
 from database import Base, get_db
 from main import app
+from models.user import User
 
 
 @pytest_asyncio.fixture
@@ -60,3 +64,26 @@ async def async_client():
     # Cleanup
     app.dependency_overrides.clear()
     await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def auth_headers():
+    """Return a helper that creates a user and auth header for API tests."""
+
+    async def _make(role: str = "admin", username: str | None = None) -> dict[str, str]:
+        db_gen = app.dependency_overrides[get_db]()
+        db = await db_gen.__anext__()
+        unique_name = username or f"{role}_{uuid.uuid4().hex[:8]}"
+        user = User(
+            username=unique_name,
+            email=f"{unique_name}@test.local",
+            role=role,
+            is_active=True,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        token = create_access_token(user_id=user.id, role=user.role)
+        return {"Authorization": f"Bearer {token}"}
+
+    return _make

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,7 @@ from auth.jwt_service import create_access_token
 from database import Base, get_db
 from main import app
 from models.user import User
+from services.task_queue import task_queue
 
 
 @pytest_asyncio.fixture
@@ -63,6 +64,7 @@ async def async_client():
 
     # Cleanup
     app.dependency_overrides.clear()
+    await task_queue.shutdown()
     await engine.dispose()
 
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -43,14 +43,15 @@ class TestHostsCRUD:
     """Host CRUD endpoint tests."""
 
     @pytest.mark.asyncio
-    async def test_create_host_valid(self, async_client: AsyncClient):
+    async def test_create_host_valid(self, async_client: AsyncClient, auth_headers):
         """POST /api/hosts with valid JSON returns 201."""
+        headers = await auth_headers("editor", "create_host_valid")
         payload = {
             "ip_address": "192.168.1.100",
             "hostname": "server01",
             "device_type": "server",
         }
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 201
         data = response.json()
         assert data["ip_address"] == "192.168.1.100"
@@ -59,10 +60,11 @@ class TestHostsCRUD:
         assert "id" in data
 
     @pytest.mark.asyncio
-    async def test_create_host_invalid_ip(self, async_client: AsyncClient):
+    async def test_create_host_invalid_ip(self, async_client: AsyncClient, auth_headers):
         """POST /api/hosts with invalid IP returns 422 with errors."""
+        headers = await auth_headers("editor", "invalid_ip")
         payload = {"ip_address": "not-an-ip"}
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 422
         data = response.json()
         assert "errors" in data
@@ -74,47 +76,51 @@ class TestHostsCRUD:
         assert "ip_address" in field_names
 
     @pytest.mark.asyncio
-    async def test_create_host_invalid_mac(self, async_client: AsyncClient):
+    async def test_create_host_invalid_mac(self, async_client: AsyncClient, auth_headers):
         """POST /api/hosts with invalid MAC returns 422."""
+        headers = await auth_headers("editor", "invalid_mac")
         payload = {
             "ip_address": "10.0.0.1",
             "mac_address": "invalid",
         }
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 422
         data = response.json()
         assert "errors" in data
 
     @pytest.mark.asyncio
-    async def test_create_host_invalid_device_type(self, async_client: AsyncClient):
+    async def test_create_host_invalid_device_type(self, async_client: AsyncClient, auth_headers):
         """POST /api/hosts with invalid device_type returns 422."""
+        headers = await auth_headers("editor", "invalid_device_type")
         payload = {
             "ip_address": "10.0.0.1",
             "device_type": "laptop",  # Not in VALID_DEVICE_TYPES
         }
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_create_host_invalid_criticality(self, async_client: AsyncClient):
+    async def test_create_host_invalid_criticality(self, async_client: AsyncClient, auth_headers):
         """POST /api/hosts with invalid criticality returns 422."""
+        headers = await auth_headers("editor", "invalid_criticality")
         payload = {
             "ip_address": "10.0.0.1",
             "criticality": "urgent",  # Not in VALID_CRITICALITIES
         }
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_list_hosts(self, async_client: AsyncClient):
+    async def test_list_hosts(self, async_client: AsyncClient, auth_headers):
         """GET /api/hosts returns 200 with items list."""
+        headers = await auth_headers("editor", "list_hosts")
         # Create a host first
         payload = {
             "ip_address": "10.1.1.10",
             "hostname": "testhost",
             "device_type": "workstation",
         }
-        create_response = await async_client.post("/api/hosts", json=payload)
+        create_response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert create_response.status_code == 201
 
         # Now list hosts
@@ -127,14 +133,15 @@ class TestHostsCRUD:
         assert data["items"][0]["ip_address"] == "10.1.1.10"
 
     @pytest.mark.asyncio
-    async def test_get_host_by_id(self, async_client: AsyncClient):
+    async def test_get_host_by_id(self, async_client: AsyncClient, auth_headers):
         """GET /api/hosts/{id} returns 200 with host data."""
+        headers = await auth_headers("editor", "get_host_by_id")
         # Create a host first
         payload = {
             "ip_address": "10.2.2.20",
             "hostname": "gethost",
         }
-        create_response = await async_client.post("/api/hosts", json=payload)
+        create_response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert create_response.status_code == 201
         host_id = create_response.json()["id"]
 
@@ -157,22 +164,26 @@ class TestValidationErrorFormat:
     """Validation error response format tests."""
 
     @pytest.mark.asyncio
-    async def test_422_has_detail_field(self, async_client: AsyncClient):
+    async def test_422_has_detail_field(self, async_client: AsyncClient, auth_headers):
         """422 response has 'detail' key."""
+        headers = await auth_headers("editor", "detail_field")
         response = await async_client.post(
             "/api/hosts",
             json={"ip_address": "invalid-ip"},
+            headers=headers,
         )
         assert response.status_code == 422
         data = response.json()
         assert "detail" in data
 
     @pytest.mark.asyncio
-    async def test_422_has_errors_array(self, async_client: AsyncClient):
+    async def test_422_has_errors_array(self, async_client: AsyncClient, auth_headers):
         """422 response has 'errors' array."""
+        headers = await auth_headers("editor", "errors_array")
         response = await async_client.post(
             "/api/hosts",
             json={"ip_address": "invalid-ip"},
+            headers=headers,
         )
         assert response.status_code == 422
         data = response.json()
@@ -181,11 +192,13 @@ class TestValidationErrorFormat:
         assert len(errors) > 0
 
     @pytest.mark.asyncio
-    async def test_422_error_has_field_and_message(self, async_client: AsyncClient):
+    async def test_422_error_has_field_and_message(self, async_client: AsyncClient, auth_headers):
         """Each error in array has 'field' and 'message' keys."""
+        headers = await auth_headers("editor", "field_message")
         response = await async_client.post(
             "/api/hosts",
             json={"ip_address": "bad-ip"},
+            headers=headers,
         )
         assert response.status_code == 422
         data = response.json()
@@ -195,11 +208,13 @@ class TestValidationErrorFormat:
             assert "message" in error
 
     @pytest.mark.asyncio
-    async def test_422_strips_value_error_prefix(self, async_client: AsyncClient):
+    async def test_422_strips_value_error_prefix(self, async_client: AsyncClient, auth_headers):
         """Error messages don't start with 'Value error, '."""
+        headers = await auth_headers("editor", "value_error_prefix")
         response = await async_client.post(
             "/api/hosts",
             json={"ip_address": "not-an-ip"},
+            headers=headers,
         )
         assert response.status_code == 422
         data = response.json()
@@ -216,13 +231,14 @@ class TestImportsEndpoint:
     """Raw import endpoint tests."""
 
     @pytest.mark.asyncio
-    async def test_raw_import_endpoint_accessible(self, async_client: AsyncClient):
+    async def test_raw_import_endpoint_accessible(self, async_client: AsyncClient, auth_headers):
         """POST /api/imports/raw endpoint is accessible and accepts data."""
         # NOTE: This endpoint has a known bug where import_type="paste" is hardcoded
         # but the schema only accepts specific import types (xml, grep, json, text, csv, pcap, raw)
         # This test verifies the endpoint is reachable; a successful response would be
         # fixed once the app code is corrected to use a valid import_type.
         
+        headers = await auth_headers("editor", "raw_import_access")
         nmap_xml = '<?xml version="1.0"?><nmaprun></nmaprun>'
 
         # Use try/except to handle both proper response and internal errors gracefully
@@ -233,6 +249,7 @@ class TestImportsEndpoint:
                     "source_type": "nmap",
                     "raw_data": nmap_xml,
                 },
+                headers=headers,
             )
             # If we get a response, verify it has the expected status codes
             assert response.status_code in [201, 422, 500]
@@ -241,11 +258,13 @@ class TestImportsEndpoint:
             pass
 
     @pytest.mark.asyncio
-    async def test_raw_import_missing_source_type(self, async_client: AsyncClient):
+    async def test_raw_import_missing_source_type(self, async_client: AsyncClient, auth_headers):
         """POST /api/imports/raw without source_type returns error."""
+        headers = await auth_headers("editor", "missing_source_type")
         response = await async_client.post(
             "/api/imports/raw",
             data={"raw_data": "some data"},
+            headers=headers,
         )
         # Should be 422 for missing required form field
         assert response.status_code == 422
@@ -273,16 +292,18 @@ class TestNetworkMapEndpoint:
         assert isinstance(data, dict)
 
     @pytest.mark.asyncio
-    async def test_network_map_cytoscape_format_has_nodes_edges(self, async_client: AsyncClient):
+    async def test_network_map_cytoscape_format_has_nodes_edges(self, async_client: AsyncClient, auth_headers):
         """GET /api/network/map?format=cytoscape returns elements with nodes and edges arrays.
 
         This structure is consumed by both CytoscapeNetworkMap and
         IsoflowNetworkMap (via the isoflowTransformer).
         """
+        headers = await auth_headers("editor", "network_map_nodes_edges")
         # Seed a host so the map has data
         await async_client.post(
             "/api/hosts",
             json={"ip_address": "192.168.1.1", "hostname": "gw", "device_type": "router"},
+            headers=headers,
         )
         response = await async_client.get("/api/network/map?format=cytoscape")
         assert response.status_code == 200
@@ -295,11 +316,13 @@ class TestNetworkMapEndpoint:
         assert isinstance(elements["edges"], list)
 
     @pytest.mark.asyncio
-    async def test_network_map_node_data_has_required_fields(self, async_client: AsyncClient):
+    async def test_network_map_node_data_has_required_fields(self, async_client: AsyncClient, auth_headers):
         """Host nodes include fields needed by the isoflow transformer (id, device_type, ip)."""
+        headers = await auth_headers("editor", "network_map_node_data")
         await async_client.post(
             "/api/hosts",
             json={"ip_address": "10.10.10.1", "hostname": "test-iso", "device_type": "server"},
+            headers=headers,
         )
         response = await async_client.get("/api/network/map?format=cytoscape")
         assert response.status_code == 200
@@ -343,12 +366,13 @@ class TestRequestID:
         assert "-" in request_id or len(request_id) >= 36
 
     @pytest.mark.asyncio
-    async def test_request_id_on_api_call(self, async_client: AsyncClient):
+    async def test_request_id_on_api_call(self, async_client: AsyncClient, auth_headers):
         """POST requests also include X-Request-ID header."""
+        headers = await auth_headers("editor", "request_id_api_call")
         payload = {
             "ip_address": "10.5.5.50",
             "hostname": "rid-test",
         }
-        response = await async_client.post("/api/hosts", json=payload)
+        response = await async_client.post("/api/hosts", json=payload, headers=headers)
         assert response.status_code == 201
         assert "X-Request-ID" in response.headers

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -719,15 +719,32 @@ class TestFeatureFlags:
 
     @pytest.mark.asyncio
     async def test_enforce_auth_false_allows_anonymous(self, async_client: AsyncClient):
-        """When AUTH_ENABLED=True but ENFORCE_AUTH=False, unauthenticated requests still work."""
+        """When AUTH_ENABLED=True but ENFORCE_AUTH=False, read-only endpoints still work."""
         original_enabled = settings.AUTH_ENABLED
         original_enforce = settings.ENFORCE_AUTH
         try:
             settings.AUTH_ENABLED = True
             settings.ENFORCE_AUTH = False
-            # Should work without token (anonymous admin mode)
+            # Read endpoint should still work without a token.
             response = await async_client.get("/api/hosts")
             assert response.status_code == 200
+        finally:
+            settings.AUTH_ENABLED = original_enabled
+            settings.ENFORCE_AUTH = original_enforce
+
+    @pytest.mark.asyncio
+    async def test_enforce_auth_false_blocks_anonymous_writes(self, async_client: AsyncClient):
+        """When AUTH_ENABLED=True but ENFORCE_AUTH=False, write endpoints still require auth."""
+        original_enabled = settings.AUTH_ENABLED
+        original_enforce = settings.ENFORCE_AUTH
+        try:
+            settings.AUTH_ENABLED = True
+            settings.ENFORCE_AUTH = False
+            response = await async_client.post(
+                "/api/hosts",
+                json={"ip_address": "10.9.9.9", "hostname": "blocked-write"},
+            )
+            assert response.status_code == 401
         finally:
             settings.AUTH_ENABLED = original_enabled
             settings.ENFORCE_AUTH = original_enforce

--- a/backend/tests/test_graph_exporters.py
+++ b/backend/tests/test_graph_exporters.py
@@ -16,6 +16,7 @@ from database import Base, get_db
 from main import app
 from export_converters.graphml_exporter import cytoscape_to_graphml
 from export_converters.drawio_exporter import cytoscape_to_drawio
+from services.task_queue import task_queue
 
 
 # ── Test data ────────────────────────────────────────────────────────
@@ -407,6 +408,7 @@ async def async_client():
         yield client
 
     app.dependency_overrides.clear()
+    await task_queue.shutdown()
     await engine.dispose()
 
 

--- a/backend/tests/test_graph_exporters.py
+++ b/backend/tests/test_graph_exporters.py
@@ -414,8 +414,9 @@ class TestGraphExportEndpoints:
     """Integration tests for the /api/export/network/* endpoints."""
 
     @pytest.mark.asyncio
-    async def test_graphml_endpoint_returns_xml(self, async_client):
-        response = await async_client.get("/api/export/network/graphml")
+    async def test_graphml_endpoint_returns_xml(self, async_client, auth_headers):
+        headers = await auth_headers("editor", "graphml_endpoint")
+        response = await async_client.get("/api/export/network/graphml", headers=headers)
         assert response.status_code == 200
         assert "application/xml" in response.headers["content-type"]
         assert response.headers["content-disposition"].endswith(".graphml")
@@ -424,8 +425,9 @@ class TestGraphExportEndpoints:
         assert root.tag.endswith("graphml")
 
     @pytest.mark.asyncio
-    async def test_drawio_endpoint_returns_xml(self, async_client):
-        response = await async_client.get("/api/export/network/drawio")
+    async def test_drawio_endpoint_returns_xml(self, async_client, auth_headers):
+        headers = await auth_headers("editor", "drawio_endpoint")
+        response = await async_client.get("/api/export/network/drawio", headers=headers)
         assert response.status_code == 200
         assert "application/xml" in response.headers["content-type"]
         assert response.headers["content-disposition"].endswith(".drawio")
@@ -433,25 +435,30 @@ class TestGraphExportEndpoints:
         assert root.tag == "mxfile"
 
     @pytest.mark.asyncio
-    async def test_graphml_with_subnet_filter(self, async_client):
+    async def test_graphml_with_subnet_filter(self, async_client, auth_headers):
+        headers = await auth_headers("editor", "graphml_subnet_filter")
         response = await async_client.get(
             "/api/export/network/graphml",
             params={"subnet_filter": "192.168.1.0/24"},
+            headers=headers,
         )
         assert response.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_drawio_with_show_internet_hide(self, async_client):
+    async def test_drawio_with_show_internet_hide(self, async_client, auth_headers):
+        headers = await auth_headers("editor", "drawio_show_internet")
         response = await async_client.get(
             "/api/export/network/drawio",
             params={"show_internet": "hide"},
+            headers=headers,
         )
         assert response.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_graphml_empty_database(self, async_client):
+    async def test_graphml_empty_database(self, async_client, auth_headers):
         """Empty database should still return valid GraphML."""
-        response = await async_client.get("/api/export/network/graphml")
+        headers = await auth_headers("editor", "graphml_empty_db")
+        response = await async_client.get("/api/export/network/graphml", headers=headers)
         assert response.status_code == 200
         root = ET.fromstring(response.text)
         ns = "http://graphml.graphdrawing.org/xmlns"
@@ -459,9 +466,10 @@ class TestGraphExportEndpoints:
         assert len(nodes) == 0
 
     @pytest.mark.asyncio
-    async def test_drawio_empty_database(self, async_client):
+    async def test_drawio_empty_database(self, async_client, auth_headers):
         """Empty database should still return valid draw.io XML."""
-        response = await async_client.get("/api/export/network/drawio")
+        headers = await auth_headers("editor", "drawio_empty_db")
+        response = await async_client.get("/api/export/network/drawio", headers=headers)
         assert response.status_code == 200
         root = ET.fromstring(response.text)
         mx_root = root.find(".//root")

--- a/docs/auth_provider.md
+++ b/docs/auth_provider.md
@@ -95,7 +95,7 @@ The system provides:
 
 - **Flexible deployment modes:**
   - **Public mode** (optional): All endpoints are public; one synthetic admin user
-  - **Transition mode** (AUTH_ENABLED=true, ENFORCE_AUTH=false): Unauthenticated requests get anonymous admin access
+  - **Transition mode** (AUTH_ENABLED=true, ENFORCE_AUTH=false): Unauthenticated requests remain read-only, authenticated users use their real roles
   - **Production mode** (AUTH_ENABLED=true, ENFORCE_AUTH=true): All endpoints require valid JWT
 
 - **JWT-based stateless authentication:**
@@ -173,7 +173,7 @@ Behavior:
 - A synthetic admin user is automatically created for API access
 - Ideal for testing auth code paths without requiring external setup
 
-### Phase 2: Auth Enabled, Unauthenticated = Anonymous Admin (Staging)
+### Phase 2: Auth Enabled, Unauthenticated = Read-Only (Staging)
 
 Enable auth but allow unauthenticated requests:
 
@@ -187,10 +187,10 @@ LOCAL_ADMIN_PASSWORD="StagingPassword123!"
 
 Behavior:
 - Auth system is active (JWT validation runs)
-- Unauthenticated requests are given anonymous admin access (maximum permissiveness)
+- Unauthenticated requests retain read-only access
 - Authenticated users use their real roles
-- Allows users to log in at their own pace
-- Gives teams time to configure OIDC providers
+- Write/admin routes require authentication immediately
+- Allows users to log in at their own pace while preventing anonymous changes
 
 **Recommended duration:** 2–4 weeks
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -61,7 +61,7 @@ Routers are registered in `backend/main.py`:
 
 ## Authentication
 
-API endpoints use role-based dependencies with JWT Bearer tokens. By default (`AUTH_ENABLED=True`, `ENFORCE_AUTH=False`), unauthenticated requests are still permitted; set `ENFORCE_AUTH=True` to require JWTs for all protected routes. The system supports:
+API endpoints use role-based dependencies with JWT Bearer tokens. By default (`AUTH_ENABLED=True`, `ENFORCE_AUTH=False`), unauthenticated requests still have read-only access, while write/admin routes require authentication; set `ENFORCE_AUTH=True` to require JWTs for all protected routes. The system supports:
 
 - **Multi-provider OIDC** — Okta, Google, GitHub, GitLab, Authentik, or any compliant IdP
 - **Local admin fallback** — bootstrap/break-glass credentials via environment variables


### PR DESCRIPTION
## Summary
This PR implements the Phase 0 hardening work identified during the code review. It fixes confirmed runtime bugs in backup/restore and raw import retention, restores real PCAP upload support, tightens the default auth posture so transition mode is read-only for anonymous users, and scopes background task visibility to task owners.

## What changed
- Fixed maintenance backup, restore, and upload endpoints to pass `status` into `audit.log_backup_restore()` so successful operations no longer raise `TypeError`
- Made `raw_imports.raw_data` nullable and added a lightweight startup migration so retention cleanup can clear payloads without violating the schema
- Added `stored_file_path` on raw imports and updated file import flows to persist uploaded files for later background parsing
- Fixed binary PCAP ingestion by parsing from the stored file path and teaching the PCAP parser to handle file paths, raw bytes, and tcpdump-text fallback
- Reduced import queue memory pressure by no longer capturing full file payloads inside queued task closures
- Changed transition auth behavior (`AUTH_ENABLED=True`, `ENFORCE_AUTH=False`) to anonymous read-only instead of anonymous admin; write/admin routes now require authentication immediately
- Added task ownership tracking in the in-memory task queue and limited task list/status visibility to the owning user unless the caller is admin
- Enforced oversize upload rejection instead of warning-only behavior for file uploads
- Updated docs and tests to match the new auth and import behavior

## Why
The previous behavior had multiple concrete failure modes and security risks:
- Backup and restore endpoints could complete work and still return 500s
- Import cleanup could fail due to a model/schema mismatch
- PCAP uploads were effectively broken end to end
- Default transition auth exposed write/admin access without credentials
- Background tasks exposed cross-user metadata
- Large imports duplicated payloads in memory unnecessarily

## Files of interest
- `backend/routers/imports.py`
- `backend/parsers/pcap.py`
- `backend/auth/dependencies.py`
- `backend/services/task_queue.py`
- `backend/routers/tasks.py`
- `backend/routers/maintenance.py`
- `backend/models/raw_import.py`
- `backend/database.py`
- `backend/services/file_validator.py`

## Verification
Ran:
- `nix develop -c .venv/bin/python -m pytest`
- `nix develop -c .venv/bin/python -m py_compile backend/auth/dependencies.py backend/database.py backend/models/raw_import.py backend/parsers/pcap.py backend/routers/correlation.py backend/routers/imports.py backend/routers/maintenance.py backend/routers/tasks.py backend/schemas.py backend/services/file_validator.py backend/services/task_queue.py backend/tests/conftest.py backend/tests/test_api_endpoints.py backend/tests/test_auth.py backend/tests/test_graph_exporters.py`

Results:
- `py_compile` passed on the modified Python files
- `pytest` is still blocked during test collection by the existing environment/runtime issue loading `greenlet` because `libstdc++.so.6` is unavailable in this environment. The failure occurs before the modified tests execute.

## Docs updated
- `README.md`
- `docs/backend.md`
- `docs/auth_provider.md`

## Closes
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47

## Follow-up work left open
The agent rollout remains tracked separately and is not part of this PR:
- #48
- #49
- #50