### PR TITLE
Add passive agent enrollment and API-key check-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ See `docs/auth_provider.md` for the full setup guide including OIDC provider con
 
 ## Docs
 
-See `docs/README.md` for the full documentation index, `docs/deployment.md` for the deployment guide, and `docs/auth_provider.md` for authentication setup.
+See `docs/README.md` for the full documentation index, `docs/deployment.md` for the deployment guide, `docs/auth_provider.md` for authentication setup, `docs/agents.md` for the passive agent backend and enrollment/API-key model, and `docs/agent_quickstart.md` for a step-by-step bootstrap and check-in walkthrough.
+
+## Passive Agents
+
+The backend now includes the first passive agent slice: agent registry records, enrollment keys, approval workflow, low-impact policy profiles, and an outbound-only check-in API that accepts compressed normalized reports and writes them into the existing host, ARP, connection, and import models. The current bootstrap model uses admin-created enrollment keys and one per-agent API key after approval.
 
 ## Deployment
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -102,6 +102,23 @@ The API will be available at `http://localhost:8000`
 ### Maintenance
 - `POST /api/maintenance/cleanup` - Cleanup tasks and data maintenance
 
+### Passive Agents
+- `GET /api/agents` - List enrolled passive agents
+- `POST /api/agents` - Create an enrolled passive agent
+- `GET /api/agents/{id}` - Get passive agent details
+- `PATCH /api/agents/{id}` - Update passive agent metadata or policy
+- `POST /api/agents/{id}/approve` - Approve a pending passive agent
+- `POST /api/agents/{id}/reject` - Reject a pending passive agent
+- `GET /api/agents/{id}/checkins` - List passive agent check-in history
+- `GET /api/agents/policies` - List passive collection policies
+- `POST /api/agents/policies` - Create passive collection policy
+- `PATCH /api/agents/policies/{id}` - Update passive collection policy
+- `GET /api/agents/enrollment-keys` - List agent enrollment keys
+- `POST /api/agents/enrollment-keys` - Create agent enrollment key
+- `PATCH /api/agents/enrollment-keys/{id}` - Update agent enrollment key
+- `POST /api/agents/register` - Register or re-poll an agent using an enrollment key
+- `POST /api/agents/check-in` - Ingest passive agent report using the agent API key
+
 ## Database Models
 
 ### Host

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,6 +51,10 @@ class Settings(BaseSettings):
     LOCAL_ADMIN_EMAIL: Optional[str] = None
     LOCAL_ADMIN_PASSWORD: Optional[str] = None
 
+    # Passive agent enrollment and API-key auth
+    AGENT_API_KEY_HEADER: str = "X-Agent-Api-Key"
+    AGENT_MAX_REPORT_BYTES: int = 262144
+
     # ── Backup Retention ────────────────────────────────────────────────
     BACKUP_MAX_COUNT: int = 10          # Keep at most N backups (0 = unlimited)
     BACKUP_MAX_AGE_DAYS: int = 30       # Delete backups older than N days (0 = unlimited)

--- a/backend/database.py
+++ b/backend/database.py
@@ -122,15 +122,55 @@ def _run_migrations(sync_conn) -> None:
     _make_column_nullable(sync_conn, "connections", "remote_port")
     _make_column_nullable(sync_conn, "raw_imports", "raw_data")
 
+    _ensure_columns(
+        sync_conn,
+        "agents",
+        [
+            ("enrollment_key_id", "enrollment_key_id INTEGER"),
+            ("approval_required", "approval_required BOOLEAN DEFAULT 1"),
+            ("api_key_hash", "api_key_hash VARCHAR(64)"),
+            ("api_key_prefix", "api_key_prefix VARCHAR(32)"),
+            ("approved_at", "approved_at DATETIME"),
+            ("rejected_at", "rejected_at DATETIME"),
+            ("api_key_issued_at", "api_key_issued_at DATETIME"),
+            ("last_registration_at", "last_registration_at DATETIME"),
+            ("last_mac_addresses", "last_mac_addresses JSON"),
+            ("last_registration_summary", "last_registration_summary JSON"),
+        ],
+    )
+    _ensure_columns(
+        sync_conn,
+        "agent_checkins",
+        [
+            ("auth_method", "auth_method VARCHAR(50)"),
+            ("api_key_prefix", "api_key_prefix VARCHAR(32)"),
+        ],
+    )
+    _create_index_if_missing(sync_conn, "idx_agent_enrollment_key_id", "agents", "enrollment_key_id")
+    _create_index_if_missing(sync_conn, "idx_agent_api_key_hash", "agents", "api_key_hash")
+    _create_index_if_missing(sync_conn, "idx_agent_api_key_prefix", "agents", "api_key_prefix")
+    _create_index_if_missing(sync_conn, "idx_agent_enrollment_key_is_active", "agent_enrollment_keys", "is_active")
+    _create_index_if_missing(sync_conn, "idx_agent_enrollment_key_default_policy_id", "agent_enrollment_keys", "default_policy_id")
+    _create_index_if_missing(sync_conn, "idx_agent_checkin_api_key_prefix", "agent_checkins", "api_key_prefix")
+
 
 def _ensure_columns(sync_conn, table: str, columns: list[tuple[str, str]]) -> None:
-    existing = [
-        row[1]
-        for row in sync_conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
-    ]
+    rows = sync_conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    if not rows:
+        return
+    existing = [row[1] for row in rows]
     for column_name, ddl in columns:
         if column_name not in existing:
             sync_conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {ddl}"))
+
+
+def _create_index_if_missing(sync_conn, index_name: str, table: str, column: str) -> None:
+    rows = sync_conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    if not rows:
+        return
+    sync_conn.execute(
+        text(f'CREATE INDEX IF NOT EXISTS {index_name} ON {table} ("{column}")')
+    )
 
 
 def _make_column_nullable(sync_conn, table: str, column: str) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from routers import (
     vlans_router,
     updates_router,
     device_identities_router,
+    agents_router,
     tasks_router,
 )
 from utils.logging_utils import setup_logging, get_logger
@@ -237,6 +238,7 @@ app.include_router(maintenance_router)
 app.include_router(vlans_router)
 app.include_router(updates_router)
 app.include_router(device_identities_router)
+app.include_router(agents_router)
 app.include_router(tasks_router)
 
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,7 @@
+from .agent import Agent
+from .agent_checkin import AgentCheckIn
+from .agent_enrollment_key import AgentEnrollmentKey
+from .agent_policy import AgentPolicy
 from .host import Host
 from .port import Port
 from .connection import Connection
@@ -15,6 +19,10 @@ __all__ = [
     "Host",
     "Port",
     "Connection",
+    "Agent",
+    "AgentCheckIn",
+    "AgentEnrollmentKey",
+    "AgentPolicy",
     "ARPEntry",
     "RawImport",
     "Conflict",

--- a/backend/models/agent.py
+++ b/backend/models/agent.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+import uuid
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+)
+
+from database import Base
+
+
+class Agent(Base):
+    """Enrolled passive agent managed by the Graphēon backend."""
+
+    __tablename__ = "agents"
+
+    id = Column(Integer, primary_key=True, index=True)
+    agent_uuid = Column(String(128), unique=True, nullable=False, index=True)
+    display_name = Column(String(255), nullable=True)
+    hostname = Column(String(255), nullable=True)
+    site_name = Column(String(255), nullable=True)
+
+    enrollment_key_id = Column(
+        Integer,
+        ForeignKey("agent_enrollment_keys.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    policy_id = Column(
+        Integer,
+        ForeignKey("agent_policies.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    enrollment_state = Column(String(20), nullable=False, default="pending", index=True)
+    approval_required = Column(Boolean, default=True, nullable=False)
+    legacy_mtls_identity = Column(
+        "mtls_identity",
+        String(500),
+        unique=True,
+        nullable=False,
+        index=True,
+        default=lambda: f"legacy:{uuid.uuid4()}",
+    )
+    api_key_hash = Column(String(64), unique=True, nullable=True, index=True)
+    api_key_prefix = Column(String(32), nullable=True, index=True)
+
+    agent_version = Column(String(100), nullable=True)
+    platform = Column(String(255), nullable=True)
+    platform_release = Column(String(255), nullable=True)
+
+    approved_at = Column(DateTime, nullable=True)
+    rejected_at = Column(DateTime, nullable=True)
+    api_key_issued_at = Column(DateTime, nullable=True)
+    last_registration_at = Column(DateTime, nullable=True)
+    last_ip_addresses = Column(JSON, nullable=True)
+    last_mac_addresses = Column(JSON, nullable=True)
+    last_registration_summary = Column(JSON, nullable=True)
+    last_checkin_summary = Column(JSON, nullable=True)
+
+    is_active = Column(Boolean, default=True, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+    last_seen_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index("idx_agent_enrollment_key_id", "enrollment_key_id"),
+        Index("idx_agent_policy_id", "policy_id"),
+        Index("idx_agent_last_seen_at", "last_seen_at"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<Agent(id={self.id}, agent_uuid={self.agent_uuid}, "
+            f"state={self.enrollment_state})>"
+        )

--- a/backend/models/agent_checkin.py
+++ b/backend/models/agent_checkin.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+)
+
+from database import Base
+
+
+class AgentCheckIn(Base):
+    """Audit record for a passive agent check-in and report ingest."""
+
+    __tablename__ = "agent_checkins"
+
+    id = Column(Integer, primary_key=True, index=True)
+    agent_id = Column(
+        Integer,
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    raw_import_id = Column(
+        Integer,
+        ForeignKey("raw_imports.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    observed_at = Column(DateTime, nullable=False)
+    received_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    sequence_number = Column(Integer, nullable=True)
+    full_snapshot = Column(Boolean, default=False, nullable=False)
+
+    content_encoding = Column(String(50), nullable=True)
+    source_ip = Column(String(64), nullable=True)
+    auth_method = Column(String(50), nullable=True)
+    api_key_prefix = Column(String(32), nullable=True)
+
+    report = Column(JSON, nullable=False)
+    summary = Column(JSON, nullable=True)
+    status = Column(String(20), nullable=False, default="accepted", index=True)
+    error_message = Column(Text, nullable=True)
+    records_created = Column(Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        Index("idx_agent_checkin_agent_received", "agent_id", "received_at"),
+        Index("idx_agent_checkin_status", "status"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<AgentCheckIn(id={self.id}, agent_id={self.agent_id}, "
+            f"status={self.status})>"
+        )

--- a/backend/models/agent_enrollment_key.py
+++ b/backend/models/agent_enrollment_key.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+
+from database import Base
+
+
+class AgentEnrollmentKey(Base):
+    """Admin-created shared enrollment credential for bootstrapping agents."""
+
+    __tablename__ = "agent_enrollment_keys"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False, index=True)
+    description = Column(Text, nullable=True)
+
+    key_hash = Column(String(64), unique=True, nullable=False, index=True)
+    key_prefix = Column(String(32), nullable=False, index=True)
+
+    default_policy_id = Column(
+        Integer,
+        ForeignKey("agent_policies.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    auto_approve = Column(Boolean, default=False, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False, index=True)
+    expires_at = Column(DateTime, nullable=True)
+    max_registrations = Column(Integer, nullable=True)
+    registration_count = Column(Integer, default=0, nullable=False)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+    last_used_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index("idx_agent_enrollment_key_is_active", "is_active"),
+        Index("idx_agent_enrollment_key_default_policy_id", "default_policy_id"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<AgentEnrollmentKey(id={self.id}, name={self.name}, "
+            f"active={self.is_active})>"
+        )

--- a/backend/models/agent_policy.py
+++ b/backend/models/agent_policy.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, JSON, String, Text
+
+from database import Base
+
+
+DEFAULT_AGENT_COMMANDS = {
+    "ip_neigh": True,
+    "ss_tunap": True,
+    "ip_addr": True,
+    "ip_route": True,
+}
+
+
+class AgentPolicy(Base):
+    """Low-impact collection profile assigned to one or more agents."""
+
+    __tablename__ = "agent_policies"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False, index=True)
+    description = Column(Text, nullable=True)
+
+    checkin_interval_seconds = Column(Integer, nullable=False, default=3600)
+    jitter_seconds = Column(Integer, nullable=False, default=300)
+    command_timeout_seconds = Column(Integer, nullable=False, default=15)
+    enabled_commands = Column(
+        JSON,
+        nullable=False,
+        default=lambda: DEFAULT_AGENT_COMMANDS.copy(),
+    )
+    max_report_bytes = Column(Integer, nullable=False, default=262144)
+
+    is_active = Column(Boolean, default=True, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    __table_args__ = (Index("idx_agent_policy_is_active", "is_active"),)
+
+    def __repr__(self):
+        return f"<AgentPolicy(id={self.id}, name={self.name}, active={self.is_active})>"

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -11,6 +11,7 @@ from .vlans import router as vlans_router
 from .updates import router as updates_router
 from .device_identities import router as device_identities_router
 from .auth import router as auth_router
+from .agents import router as agents_router
 from .tasks import router as tasks_router
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "updates_router",
     "device_identities_router",
     "auth_router",
+    "agents_router",
     "tasks_router",
 ]

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -1,0 +1,1391 @@
+import gzip
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timezone
+from ipaddress import ip_address as parse_ip
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import require_admin, require_any_authenticated
+from config import settings
+from database import get_db
+from models import (
+    ARPEntry,
+    Agent,
+    AgentCheckIn,
+    AgentEnrollmentKey,
+    AgentPolicy,
+    Connection,
+    Host,
+    RawImport,
+    User,
+)
+from schemas import (
+    AgentApprovalRequest,
+    AgentCheckInRecordResponse,
+    AgentCheckInRequest,
+    AgentCheckInResponse,
+    AgentCreate,
+    AgentEnrollmentKeyCreate,
+    AgentEnrollmentKeyCreateResponse,
+    AgentEnrollmentKeyResponse,
+    AgentEnrollmentKeyUpdate,
+    AgentPolicyCreate,
+    AgentPolicyResponse,
+    AgentPolicyUpdate,
+    AgentRegistrationRequest,
+    AgentRegistrationResponse,
+    AgentRejectRequest,
+    AgentResponse,
+    AgentUpdate,
+    PaginatedResponse,
+)
+from utils.audit import audit
+from utils.tagging import (
+    build_arp_tags,
+    build_connection_tags,
+    build_host_tags,
+    merge_tags,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+
+AGENT_SOURCE_TYPE = "agent"
+AGENT_IMPORT_TYPE = "agent"
+ENROLLMENT_KEY_PREFIX = "gaek"
+AGENT_API_KEY_PREFIX = "gpak"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _hash_secret(raw_secret: str) -> str:
+    return hashlib.sha256(raw_secret.encode("utf-8")).hexdigest()
+
+
+def _generate_secret(prefix: str) -> tuple[str, str]:
+    token = f"{prefix}_{secrets.token_urlsafe(32)}"
+    return token, token[:20]
+
+
+def _decode_request_body(body: bytes, content_encoding: Optional[str]) -> bytes:
+    if not content_encoding:
+        return body
+    if content_encoding.lower() != "gzip":
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported content encoding '{content_encoding}'",
+        )
+    try:
+        return gzip.decompress(body)
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid gzip payload: {exc}")
+
+
+def _source_host_from_payload(payload: AgentCheckInRequest) -> Optional[str]:
+    if payload.hostname:
+        return payload.hostname
+    if payload.addresses:
+        return payload.addresses[0].ip_address
+    return None
+
+
+def _extract_registration_summary(payload: AgentRegistrationRequest) -> tuple[list[str], list[str], dict]:
+    ips = sorted({address.ip_address for address in payload.addresses})
+    macs = sorted(
+        {
+            address.mac_address
+            for address in payload.addresses
+            if address.mac_address is not None
+        }
+    )
+    summary = {
+        "address_count": len(payload.addresses),
+        "ip_addresses": ips,
+        "mac_addresses": macs,
+        "metadata": payload.metadata or {},
+    }
+    return ips, macs, summary
+
+
+async def _get_policy_or_404(db: AsyncSession, policy_id: int) -> AgentPolicy:
+    result = await db.execute(select(AgentPolicy).where(AgentPolicy.id == policy_id))
+    policy = result.scalar_one_or_none()
+    if not policy:
+        raise HTTPException(status_code=404, detail="Agent policy not found")
+    return policy
+
+
+async def _get_enrollment_key_or_404(
+    db: AsyncSession,
+    enrollment_key_id: int,
+) -> AgentEnrollmentKey:
+    result = await db.execute(
+        select(AgentEnrollmentKey).where(AgentEnrollmentKey.id == enrollment_key_id)
+    )
+    enrollment_key = result.scalar_one_or_none()
+    if not enrollment_key:
+        raise HTTPException(status_code=404, detail="Enrollment key not found")
+    return enrollment_key
+
+
+async def _get_agent_or_404(db: AsyncSession, agent_id: int) -> Agent:
+    result = await db.execute(select(Agent).where(Agent.id == agent_id))
+    agent = result.scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+async def _load_policy_map(
+    db: AsyncSession,
+    policy_ids: list[int],
+) -> dict[int, AgentPolicy]:
+    if not policy_ids:
+        return {}
+    result = await db.execute(
+        select(AgentPolicy).where(AgentPolicy.id.in_(sorted(set(policy_ids))))
+    )
+    policies = result.scalars().all()
+    return {policy.id: policy for policy in policies}
+
+
+async def _load_enrollment_key_map(
+    db: AsyncSession,
+    enrollment_key_ids: list[int],
+) -> dict[int, AgentEnrollmentKey]:
+    if not enrollment_key_ids:
+        return {}
+    result = await db.execute(
+        select(AgentEnrollmentKey).where(
+            AgentEnrollmentKey.id.in_(sorted(set(enrollment_key_ids)))
+        )
+    )
+    enrollment_keys = result.scalars().all()
+    return {enrollment_key.id: enrollment_key for enrollment_key in enrollment_keys}
+
+
+async def _attach_key_and_policy(
+    agent: Agent,
+    policy_map: dict[int, AgentPolicy],
+    enrollment_key_map: dict[int, AgentEnrollmentKey],
+) -> None:
+    if agent.policy_id and agent.policy_id in policy_map:
+        setattr(agent, "policy", AgentPolicyResponse.model_validate(policy_map[agent.policy_id]))
+    if agent.enrollment_key_id and agent.enrollment_key_id in enrollment_key_map:
+        enrollment_key = enrollment_key_map[agent.enrollment_key_id]
+        if enrollment_key.default_policy_id and enrollment_key.default_policy_id in policy_map:
+            setattr(
+                enrollment_key,
+                "default_policy",
+                AgentPolicyResponse.model_validate(
+                    policy_map[enrollment_key.default_policy_id]
+                ),
+            )
+        setattr(
+            agent,
+            "enrollment_key",
+            AgentEnrollmentKeyResponse.model_validate(enrollment_key),
+        )
+
+
+async def _attach_default_policy_to_enrollment_key(
+    enrollment_key: AgentEnrollmentKey,
+    policy_map: dict[int, AgentPolicy],
+) -> None:
+    if (
+        enrollment_key.default_policy_id
+        and enrollment_key.default_policy_id in policy_map
+    ):
+        setattr(
+            enrollment_key,
+            "default_policy",
+            AgentPolicyResponse.model_validate(
+                policy_map[enrollment_key.default_policy_id]
+            ),
+        )
+
+
+async def _lookup_enrollment_key_by_secret(
+    db: AsyncSession,
+    raw_key: str,
+) -> AgentEnrollmentKey:
+    result = await db.execute(
+        select(AgentEnrollmentKey).where(
+            AgentEnrollmentKey.key_hash == _hash_secret(raw_key),
+            AgentEnrollmentKey.is_active.is_(True),
+        )
+    )
+    enrollment_key = result.scalar_one_or_none()
+    if not enrollment_key:
+        raise HTTPException(status_code=401, detail="Invalid enrollment key")
+
+    now = _utcnow()
+    if enrollment_key.expires_at and enrollment_key.expires_at < now:
+        raise HTTPException(status_code=403, detail="Enrollment key has expired")
+    return enrollment_key
+
+
+async def _lookup_agent_by_api_key(
+    db: AsyncSession,
+    raw_api_key: str,
+) -> Agent:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.api_key_hash == _hash_secret(raw_api_key),
+            Agent.is_active.is_(True),
+        )
+    )
+    agent = result.scalar_one_or_none()
+    if not agent:
+        raise HTTPException(status_code=401, detail="Invalid agent API key")
+    if agent.enrollment_state != "active":
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent is not approved for check-in ({agent.enrollment_state})",
+        )
+    return agent
+
+
+async def _upsert_host(
+    db: AsyncSession,
+    ip_address: str,
+    hostname: Optional[str] = None,
+    mac_address: Optional[str] = None,
+) -> tuple[Host, bool]:
+    try:
+        if parse_ip(ip_address).is_unspecified:
+            raise ValueError
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid host IP '{ip_address}'")
+
+    result = await db.execute(select(Host).where(Host.ip_address == ip_address))
+    host = result.scalar_one_or_none()
+    created = False
+
+    if host:
+        if hostname:
+            host.hostname = hostname
+        if mac_address and not host.mac_address:
+            host.mac_address = mac_address
+        current_sources = host.source_types or []
+        if AGENT_SOURCE_TYPE not in current_sources:
+            host.source_types = current_sources + [AGENT_SOURCE_TYPE]
+        host.tags = merge_tags(
+            host.tags,
+            build_host_tags(
+                ip_address=host.ip_address,
+                mac_address=host.mac_address,
+                hostname=host.hostname,
+                fqdn=host.fqdn,
+                vendor=host.vendor,
+                os_family=host.os_family,
+                os_name=host.os_name,
+            ),
+        )
+        host.last_seen = _utcnow()
+        return host, created
+
+    host = Host(
+        ip_address=ip_address,
+        hostname=hostname,
+        mac_address=mac_address,
+        source_types=[AGENT_SOURCE_TYPE],
+        first_seen=_utcnow(),
+        last_seen=_utcnow(),
+    )
+    host.tags = build_host_tags(
+        ip_address=host.ip_address,
+        mac_address=host.mac_address,
+        hostname=host.hostname,
+    )
+    db.add(host)
+    await db.flush()
+    return host, True
+
+
+async def _upsert_arp_entry(
+    db: AsyncSession,
+    ip_address: str,
+    mac_address: Optional[str],
+    interface: Optional[str],
+    state_value: Optional[str],
+) -> bool:
+    if not mac_address:
+        return False
+
+    result = await db.execute(
+        select(ARPEntry).where(
+            ARPEntry.ip_address == ip_address,
+            ARPEntry.mac_address == mac_address,
+        )
+    )
+    arp_entry = result.scalar_one_or_none()
+    if arp_entry:
+        arp_entry.interface = interface or arp_entry.interface
+        arp_entry.entry_type = state_value or arp_entry.entry_type
+        arp_entry.last_seen = _utcnow()
+        arp_entry.tags = merge_tags(
+            arp_entry.tags,
+            build_arp_tags(
+                ip_address=arp_entry.ip_address,
+                mac_address=arp_entry.mac_address,
+                interface=arp_entry.interface,
+                entry_type=arp_entry.entry_type,
+                vendor=arp_entry.vendor,
+            ),
+        )
+        return False
+
+    arp_entry = ARPEntry(
+        ip_address=ip_address,
+        mac_address=mac_address,
+        interface=interface,
+        entry_type=state_value,
+        source_type=AGENT_SOURCE_TYPE,
+        first_seen=_utcnow(),
+        last_seen=_utcnow(),
+    )
+    arp_entry.tags = build_arp_tags(
+        ip_address=arp_entry.ip_address,
+        mac_address=arp_entry.mac_address,
+        interface=arp_entry.interface,
+        entry_type=arp_entry.entry_type,
+        vendor=arp_entry.vendor,
+    )
+    db.add(arp_entry)
+    return True
+
+
+async def _upsert_connection(
+    db: AsyncSession,
+    local_ip: str,
+    local_port: int,
+    remote_ip: str,
+    remote_port: Optional[int],
+    protocol: str,
+    state_value: Optional[str],
+    pid: Optional[int],
+    process_name: Optional[str],
+) -> bool:
+    filters = [
+        Connection.local_ip == local_ip,
+        Connection.local_port == local_port,
+        Connection.remote_ip == remote_ip,
+        Connection.protocol == protocol,
+        Connection.state == state_value,
+        Connection.pid == pid,
+        Connection.process_name == process_name,
+    ]
+    if remote_port is None:
+        filters.append(Connection.remote_port.is_(None))
+    else:
+        filters.append(Connection.remote_port == remote_port)
+
+    result = await db.execute(select(Connection).where(*filters))
+    connection = result.scalar_one_or_none()
+    if connection:
+        connection.last_seen = _utcnow()
+        connection.tags = merge_tags(
+            connection.tags,
+            build_connection_tags(
+                local_ip=connection.local_ip,
+                local_port=connection.local_port,
+                remote_ip=connection.remote_ip,
+                remote_port=connection.remote_port,
+                protocol=connection.protocol,
+                state=connection.state,
+                process_name=connection.process_name,
+            ),
+        )
+        return False
+
+    connection = Connection(
+        local_ip=local_ip,
+        local_port=local_port,
+        remote_ip=remote_ip,
+        remote_port=remote_port,
+        protocol=protocol,
+        state=state_value,
+        pid=pid,
+        process_name=process_name,
+        source_type=AGENT_SOURCE_TYPE,
+        first_seen=_utcnow(),
+        last_seen=_utcnow(),
+    )
+    connection.tags = build_connection_tags(
+        local_ip=connection.local_ip,
+        local_port=connection.local_port,
+        remote_ip=connection.remote_ip,
+        remote_port=connection.remote_port,
+        protocol=connection.protocol,
+        state=connection.state,
+        process_name=connection.process_name,
+    )
+    db.add(connection)
+    return True
+
+
+async def _ingest_agent_payload(
+    db: AsyncSession,
+    agent: Agent,
+    payload: AgentCheckInRequest,
+    decoded_body: bytes,
+    content_encoding: Optional[str],
+    source_ip: Optional[str],
+) -> tuple[AgentCheckIn, RawImport, AgentPolicyResponse | None, dict]:
+    now = _utcnow()
+    host_creates = 0
+    arp_creates = 0
+    connection_creates = 0
+
+    seen_ips: set[str] = set()
+    seen_macs: set[str] = set()
+
+    for address in payload.addresses:
+        _, created = await _upsert_host(
+            db,
+            address.ip_address,
+            hostname=payload.hostname,
+            mac_address=address.mac_address,
+        )
+        host_creates += int(created)
+        seen_ips.add(address.ip_address)
+        if address.mac_address:
+            seen_macs.add(address.mac_address)
+
+    for neighbor in payload.neighbors:
+        _, created = await _upsert_host(
+            db,
+            neighbor.ip_address,
+            hostname=neighbor.hostname,
+            mac_address=neighbor.mac_address,
+        )
+        host_creates += int(created)
+        arp_created = await _upsert_arp_entry(
+            db,
+            neighbor.ip_address,
+            neighbor.mac_address,
+            neighbor.interface,
+            neighbor.state,
+        )
+        arp_creates += int(arp_created)
+        seen_ips.add(neighbor.ip_address)
+        if neighbor.mac_address:
+            seen_macs.add(neighbor.mac_address)
+
+    for route in payload.routes:
+        if route.source_ip:
+            _, created = await _upsert_host(
+                db,
+                route.source_ip,
+                hostname=payload.hostname,
+            )
+            host_creates += int(created)
+            seen_ips.add(route.source_ip)
+        if route.gateway:
+            _, created = await _upsert_host(db, route.gateway)
+            host_creates += int(created)
+            seen_ips.add(route.gateway)
+
+    for connection in payload.connections:
+        _, created = await _upsert_host(
+            db,
+            connection.local_ip,
+            hostname=payload.hostname,
+        )
+        host_creates += int(created)
+        seen_ips.add(connection.local_ip)
+        if not parse_ip(connection.remote_ip).is_unspecified:
+            _, remote_created = await _upsert_host(db, connection.remote_ip)
+            host_creates += int(remote_created)
+            seen_ips.add(connection.remote_ip)
+        connection_created = await _upsert_connection(
+            db,
+            local_ip=connection.local_ip,
+            local_port=connection.local_port,
+            remote_ip=connection.remote_ip,
+            remote_port=connection.remote_port,
+            protocol=connection.protocol,
+            state_value=connection.state,
+            pid=connection.pid,
+            process_name=connection.process_name,
+        )
+        connection_creates += int(connection_created)
+
+    raw_import = RawImport(
+        source_type=AGENT_SOURCE_TYPE,
+        import_type=AGENT_IMPORT_TYPE,
+        filename=f"{agent.agent_uuid}-{payload.observed_at.isoformat()}.json",
+        source_host=_source_host_from_payload(payload),
+        raw_data=decoded_body.decode("utf-8"),
+        tags=["agent", f"agent_uuid:{agent.agent_uuid}"],
+        notes="Passive agent check-in",
+        parse_status="success",
+        parsed_count=host_creates + arp_creates + connection_creates,
+        parse_results={
+            "observed_at": payload.observed_at.isoformat(),
+            "sequence_number": payload.sequence_number,
+            "full_snapshot": payload.full_snapshot,
+            "counts": {
+                "hosts_created": host_creates,
+                "arp_entries_created": arp_creates,
+                "connections_created": connection_creates,
+                "addresses_seen": len(payload.addresses),
+                "neighbors_seen": len(payload.neighbors),
+                "routes_seen": len(payload.routes),
+            },
+            "content_encoding": content_encoding or "identity",
+            "auth_method": "api_key",
+        },
+        created_at=now,
+        processed_at=now,
+    )
+    db.add(raw_import)
+    await db.flush()
+
+    summary = {
+        "hosts_created": host_creates,
+        "arp_entries_created": arp_creates,
+        "connections_created": connection_creates,
+        "ip_addresses_seen": sorted(seen_ips),
+        "mac_addresses_seen": sorted(seen_macs),
+        "neighbor_count": len(payload.neighbors),
+        "connection_count": len(payload.connections),
+        "route_count": len(payload.routes),
+        "raw_import_id": raw_import.id,
+    }
+
+    checkin = AgentCheckIn(
+        agent_id=agent.id,
+        raw_import_id=raw_import.id,
+        observed_at=payload.observed_at,
+        received_at=now,
+        sequence_number=payload.sequence_number,
+        full_snapshot=payload.full_snapshot,
+        content_encoding=content_encoding or "identity",
+        source_ip=source_ip,
+        auth_method="api_key",
+        api_key_prefix=agent.api_key_prefix,
+        report=payload.model_dump(mode="json"),
+        summary=summary,
+        status="accepted",
+        records_created=host_creates + arp_creates + connection_creates,
+    )
+    db.add(checkin)
+
+    agent.hostname = payload.hostname or agent.hostname
+    agent.agent_version = payload.agent_version or agent.agent_version
+    agent.platform = payload.platform or agent.platform
+    agent.platform_release = payload.platform_release or agent.platform_release
+    agent.last_ip_addresses = sorted(seen_ips)
+    agent.last_mac_addresses = sorted(seen_macs)
+    agent.last_checkin_summary = summary
+    agent.last_seen_at = now
+
+    await db.flush()
+
+    policy = None
+    if agent.policy_id:
+        result = await db.execute(select(AgentPolicy).where(AgentPolicy.id == agent.policy_id))
+        policy = result.scalar_one_or_none()
+
+    return (
+        checkin,
+        raw_import,
+        AgentPolicyResponse.model_validate(policy) if policy else None,
+        summary,
+    )
+
+
+def _agent_response(agent: Agent) -> AgentResponse:
+    return AgentResponse.model_validate(agent)
+
+
+@router.get("/policies", response_model=PaginatedResponse)
+async def list_policies(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=1000),
+    is_active: Optional[bool] = Query(None),
+    user: User = Depends(require_any_authenticated),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(AgentPolicy)
+    count_query = select(func.count(AgentPolicy.id))
+
+    if is_active is not None:
+        query = query.where(AgentPolicy.is_active == is_active)
+        count_query = count_query.where(AgentPolicy.is_active == is_active)
+
+    total = (await db.execute(count_query)).scalar_one()
+    result = await db.execute(
+        query.order_by(AgentPolicy.name.asc()).offset(skip).limit(limit)
+    )
+    policies = result.scalars().all()
+
+    policy_ids = [policy.id for policy in policies]
+    counts: dict[int, int] = {}
+    if policy_ids:
+        count_rows = await db.execute(
+            select(Agent.policy_id, func.count(Agent.id))
+            .where(Agent.policy_id.in_(policy_ids))
+            .group_by(Agent.policy_id)
+        )
+        counts = {row[0]: row[1] for row in count_rows.all()}
+
+    for policy in policies:
+        setattr(policy, "agent_count", counts.get(policy.id, 0))
+
+    return {
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "items": [AgentPolicyResponse.model_validate(policy) for policy in policies],
+    }
+
+
+@router.post("/policies", response_model=AgentPolicyResponse, status_code=201)
+async def create_policy(
+    policy: AgentPolicyCreate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    db_policy = AgentPolicy(**policy.model_dump())
+    db.add(db_policy)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Agent policy name already exists")
+
+    await db.refresh(db_policy)
+    audit.log(
+        action="CREATE",
+        actor="user",
+        resource="AgentPolicy",
+        resource_id=str(db_policy.id),
+        status="success",
+        details={"name": db_policy.name},
+    )
+    return AgentPolicyResponse.model_validate(db_policy)
+
+
+@router.patch("/policies/{policy_id}", response_model=AgentPolicyResponse)
+async def update_policy(
+    policy_id: int,
+    policy_update: AgentPolicyUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    policy = await _get_policy_or_404(db, policy_id)
+
+    for field, value in policy_update.model_dump(exclude_unset=True).items():
+        setattr(policy, field, value)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Agent policy name already exists")
+
+    await db.refresh(policy)
+    audit.log(
+        action="UPDATE",
+        actor="user",
+        resource="AgentPolicy",
+        resource_id=str(policy.id),
+        status="success",
+        details={"name": policy.name},
+    )
+    return AgentPolicyResponse.model_validate(policy)
+
+
+@router.get("/enrollment-keys", response_model=PaginatedResponse)
+async def list_enrollment_keys(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=1000),
+    is_active: Optional[bool] = Query(None),
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(AgentEnrollmentKey)
+    count_query = select(func.count(AgentEnrollmentKey.id))
+    if is_active is not None:
+        query = query.where(AgentEnrollmentKey.is_active == is_active)
+        count_query = count_query.where(AgentEnrollmentKey.is_active == is_active)
+
+    total = (await db.execute(count_query)).scalar_one()
+    result = await db.execute(
+        query.order_by(AgentEnrollmentKey.name.asc()).offset(skip).limit(limit)
+    )
+    enrollment_keys = result.scalars().all()
+    policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_keys
+            if enrollment_key.default_policy_id
+        ],
+    )
+    for enrollment_key in enrollment_keys:
+        await _attach_default_policy_to_enrollment_key(enrollment_key, policy_map)
+
+    return {
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "items": [
+            AgentEnrollmentKeyResponse.model_validate(enrollment_key)
+            for enrollment_key in enrollment_keys
+        ],
+    }
+
+
+@router.post(
+    "/enrollment-keys",
+    response_model=AgentEnrollmentKeyCreateResponse,
+    status_code=201,
+)
+async def create_enrollment_key(
+    enrollment_key: AgentEnrollmentKeyCreate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    if enrollment_key.default_policy_id is not None:
+        await _get_policy_or_404(db, enrollment_key.default_policy_id)
+
+    raw_key, key_prefix = _generate_secret(ENROLLMENT_KEY_PREFIX)
+    db_enrollment_key = AgentEnrollmentKey(
+        **enrollment_key.model_dump(),
+        key_hash=_hash_secret(raw_key),
+        key_prefix=key_prefix,
+    )
+    db.add(db_enrollment_key)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Enrollment key name already exists")
+
+    await db.refresh(db_enrollment_key)
+    if db_enrollment_key.default_policy_id:
+        policy_map = await _load_policy_map(db, [db_enrollment_key.default_policy_id])
+        await _attach_default_policy_to_enrollment_key(db_enrollment_key, policy_map)
+
+    audit.log(
+        action="CREATE",
+        actor="user",
+        resource="AgentEnrollmentKey",
+        resource_id=str(db_enrollment_key.id),
+        status="success",
+        details={"name": db_enrollment_key.name},
+    )
+    return AgentEnrollmentKeyCreateResponse(
+        enrollment_key=raw_key,
+        key=AgentEnrollmentKeyResponse.model_validate(db_enrollment_key),
+    )
+
+
+@router.patch("/enrollment-keys/{enrollment_key_id}", response_model=AgentEnrollmentKeyResponse)
+async def update_enrollment_key(
+    enrollment_key_id: int,
+    enrollment_key_update: AgentEnrollmentKeyUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    enrollment_key = await _get_enrollment_key_or_404(db, enrollment_key_id)
+    update_data = enrollment_key_update.model_dump(exclude_unset=True)
+
+    if "default_policy_id" in update_data and update_data["default_policy_id"] is not None:
+        await _get_policy_or_404(db, update_data["default_policy_id"])
+
+    for field, value in update_data.items():
+        setattr(enrollment_key, field, value)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Enrollment key name already exists")
+
+    await db.refresh(enrollment_key)
+    if enrollment_key.default_policy_id:
+        policy_map = await _load_policy_map(db, [enrollment_key.default_policy_id])
+        await _attach_default_policy_to_enrollment_key(enrollment_key, policy_map)
+
+    audit.log(
+        action="UPDATE",
+        actor="user",
+        resource="AgentEnrollmentKey",
+        resource_id=str(enrollment_key.id),
+        status="success",
+        details={"name": enrollment_key.name},
+    )
+    return AgentEnrollmentKeyResponse.model_validate(enrollment_key)
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_agents(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=1000),
+    enrollment_state: Optional[str] = Query(None),
+    is_active: Optional[bool] = Query(None),
+    user: User = Depends(require_any_authenticated),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(Agent)
+    count_query = select(func.count(Agent.id))
+
+    if enrollment_state:
+        query = query.where(Agent.enrollment_state == enrollment_state.lower())
+        count_query = count_query.where(Agent.enrollment_state == enrollment_state.lower())
+    if is_active is not None:
+        query = query.where(Agent.is_active == is_active)
+        count_query = count_query.where(Agent.is_active == is_active)
+
+    total = (await db.execute(count_query)).scalar_one()
+    result = await db.execute(
+        query.order_by(Agent.last_seen_at.is_(None), Agent.last_seen_at.desc(), Agent.id.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    agents = result.scalars().all()
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id for agent in agents if agent.policy_id],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id for agent in agents if agent.enrollment_key_id],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    for agent in agents:
+        await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    return {
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "items": [_agent_response(agent) for agent in agents],
+    }
+
+
+@router.post("", response_model=AgentResponse, status_code=201)
+async def create_agent(
+    agent: AgentCreate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    if agent.policy_id is not None:
+        await _get_policy_or_404(db, agent.policy_id)
+    if agent.enrollment_key_id is not None:
+        await _get_enrollment_key_or_404(db, agent.enrollment_key_id)
+
+    db_agent = Agent(**agent.model_dump())
+    db.add(db_agent)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Agent UUID already exists")
+
+    await db.refresh(db_agent)
+    policy_map = await _load_policy_map(
+        db,
+        [db_agent.policy_id] if db_agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [db_agent.enrollment_key_id] if db_agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(db_agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="CREATE",
+        actor="user",
+        resource="Agent",
+        resource_id=str(db_agent.id),
+        status="success",
+        details={"agent_uuid": db_agent.agent_uuid},
+    )
+    return _agent_response(db_agent)
+
+
+@router.post("/register", response_model=AgentRegistrationResponse)
+async def register_agent(
+    registration: AgentRegistrationRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    enrollment_key = await _lookup_enrollment_key_by_secret(db, registration.enrollment_key)
+    now = _utcnow()
+    ip_addresses, mac_addresses, registration_summary = _extract_registration_summary(registration)
+
+    result = await db.execute(select(Agent).where(Agent.agent_uuid == registration.agent_uuid))
+    agent = result.scalar_one_or_none()
+    created = False
+    issued_api_key: Optional[str] = None
+
+    if agent and agent.enrollment_state in {"rejected", "revoked"}:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent registration is {agent.enrollment_state}",
+        )
+
+    if agent and agent.enrollment_key_id not in (None, enrollment_key.id):
+        raise HTTPException(
+            status_code=409,
+            detail="Agent UUID is already associated with a different enrollment key",
+        )
+
+    if (
+        agent is None
+        and enrollment_key.max_registrations is not None
+        and enrollment_key.registration_count >= enrollment_key.max_registrations
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Enrollment key registration limit reached",
+        )
+
+    if agent is None:
+        agent = Agent(
+            agent_uuid=registration.agent_uuid,
+            display_name=registration.display_name,
+            hostname=registration.hostname,
+            site_name=registration.site_name,
+            enrollment_key_id=enrollment_key.id,
+            policy_id=enrollment_key.default_policy_id,
+            enrollment_state="active" if enrollment_key.auto_approve else "pending",
+            approval_required=not enrollment_key.auto_approve,
+            agent_version=registration.agent_version,
+            platform=registration.platform,
+            platform_release=registration.platform_release,
+            last_registration_at=now,
+            last_ip_addresses=ip_addresses,
+            last_mac_addresses=mac_addresses,
+            last_registration_summary=registration_summary,
+            is_active=True,
+            approved_at=now if enrollment_key.auto_approve else None,
+        )
+        db.add(agent)
+        enrollment_key.registration_count += 1
+        created = True
+    else:
+        agent.display_name = registration.display_name or agent.display_name
+        agent.hostname = registration.hostname or agent.hostname
+        agent.site_name = registration.site_name or agent.site_name
+        agent.agent_version = registration.agent_version or agent.agent_version
+        agent.platform = registration.platform or agent.platform
+        agent.platform_release = registration.platform_release or agent.platform_release
+        agent.last_registration_at = now
+        agent.last_ip_addresses = ip_addresses
+        agent.last_mac_addresses = mac_addresses
+        agent.last_registration_summary = registration_summary
+        if agent.policy_id is None and enrollment_key.default_policy_id is not None:
+            agent.policy_id = enrollment_key.default_policy_id
+        if enrollment_key.auto_approve and agent.enrollment_state == "pending":
+            agent.enrollment_state = "active"
+            agent.approval_required = False
+            agent.approved_at = now
+
+    enrollment_key.last_used_at = now
+    await db.flush()
+
+    if agent.enrollment_state == "active" and not agent.api_key_hash:
+        raw_api_key, api_key_prefix = _generate_secret(AGENT_API_KEY_PREFIX)
+        agent.api_key_hash = _hash_secret(raw_api_key)
+        agent.api_key_prefix = api_key_prefix
+        agent.api_key_issued_at = now
+        issued_api_key = raw_api_key
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        if created:
+            raise HTTPException(status_code=409, detail="Agent UUID already exists")
+        raise HTTPException(status_code=409, detail="Failed to persist agent registration")
+
+    await db.refresh(agent)
+    policy_map = await _load_policy_map(
+        db,
+        [policy_id for policy_id in [agent.policy_id, enrollment_key.default_policy_id] if policy_id],
+    )
+    enrollment_key_map = {enrollment_key.id: enrollment_key}
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="REGISTER",
+        actor=f"agent:{agent.agent_uuid}",
+        resource="Agent",
+        resource_id=str(agent.id),
+        status="success",
+        details={
+            "created": created,
+            "state": agent.enrollment_state,
+            "enrollment_key_id": enrollment_key.id,
+        },
+    )
+
+    if agent.enrollment_state == "pending":
+        return AgentRegistrationResponse(
+            status="pending",
+            approval_required=True,
+            message="Agent registered and is awaiting admin approval",
+            api_key=None,
+            server_time=_utcnow(),
+            agent=_agent_response(agent),
+            policy=AgentPolicyResponse.model_validate(policy_map[agent.policy_id]) if agent.policy_id else None,
+        )
+
+    return AgentRegistrationResponse(
+        status="active",
+        approval_required=False,
+        message=(
+            "Agent approved and API key issued"
+            if issued_api_key
+            else "Agent already approved"
+        ),
+        api_key=issued_api_key,
+        server_time=_utcnow(),
+        agent=_agent_response(agent),
+        policy=AgentPolicyResponse.model_validate(policy_map[agent.policy_id]) if agent.policy_id else None,
+    )
+
+
+@router.post("/{agent_id}/approve", response_model=AgentResponse)
+async def approve_agent(
+    agent_id: int,
+    approval: AgentApprovalRequest,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _get_agent_or_404(db, agent_id)
+    if approval.policy_id is not None:
+        await _get_policy_or_404(db, approval.policy_id)
+
+    agent.enrollment_state = "active"
+    agent.approval_required = False
+    agent.approved_at = _utcnow()
+    agent.rejected_at = None
+    if approval.policy_id is not None:
+        agent.policy_id = approval.policy_id
+    if approval.display_name:
+        agent.display_name = approval.display_name
+
+    await db.commit()
+    await db.refresh(agent)
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id] if agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id] if agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="APPROVE",
+        actor="user",
+        resource="Agent",
+        resource_id=str(agent.id),
+        status="success",
+        details={"agent_uuid": agent.agent_uuid},
+    )
+    return _agent_response(agent)
+
+
+@router.post("/{agent_id}/reject", response_model=AgentResponse)
+async def reject_agent(
+    agent_id: int,
+    rejection: AgentRejectRequest,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _get_agent_or_404(db, agent_id)
+    agent.enrollment_state = "rejected"
+    agent.approval_required = True
+    agent.rejected_at = _utcnow()
+    if rejection.reason:
+        summary = agent.last_registration_summary or {}
+        summary["rejection_reason"] = rejection.reason
+        agent.last_registration_summary = summary
+
+    await db.commit()
+    await db.refresh(agent)
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id] if agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id] if agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="REJECT",
+        actor="user",
+        resource="Agent",
+        resource_id=str(agent.id),
+        status="success",
+        details={"agent_uuid": agent.agent_uuid},
+    )
+    return _agent_response(agent)
+
+
+@router.get("/{agent_id}/checkins", response_model=PaginatedResponse)
+async def list_agent_checkins(
+    agent_id: int,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=1000),
+    user: User = Depends(require_any_authenticated),
+    db: AsyncSession = Depends(get_db),
+):
+    await _get_agent_or_404(db, agent_id)
+
+    total = (
+        await db.execute(
+            select(func.count(AgentCheckIn.id)).where(AgentCheckIn.agent_id == agent_id)
+        )
+    ).scalar_one()
+    result = await db.execute(
+        select(AgentCheckIn)
+        .where(AgentCheckIn.agent_id == agent_id)
+        .order_by(AgentCheckIn.received_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    checkins = result.scalars().all()
+
+    return {
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "items": [
+            AgentCheckInRecordResponse.model_validate(checkin) for checkin in checkins
+        ],
+    }
+
+
+@router.post("/check-in", response_model=AgentCheckInResponse)
+async def agent_check_in(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    raw_api_key = request.headers.get(settings.AGENT_API_KEY_HEADER)
+    if not raw_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing agent API key",
+        )
+
+    agent = await _lookup_agent_by_api_key(db, raw_api_key)
+
+    raw_body = await request.body()
+    if len(raw_body) > settings.AGENT_MAX_REPORT_BYTES:
+        raise HTTPException(status_code=413, detail="Compressed report exceeds server limit")
+
+    decoded_body = _decode_request_body(raw_body, request.headers.get("content-encoding"))
+
+    policy = None
+    if agent.policy_id:
+        result = await db.execute(select(AgentPolicy).where(AgentPolicy.id == agent.policy_id))
+        policy = result.scalar_one_or_none()
+
+    max_report_bytes = policy.max_report_bytes if policy else settings.AGENT_MAX_REPORT_BYTES
+    if len(decoded_body) > max_report_bytes:
+        raise HTTPException(status_code=413, detail="Decoded report exceeds policy size limit")
+
+    try:
+        payload = AgentCheckInRequest.model_validate_json(decoded_body)
+    except ValidationError as exc:
+        raise RequestValidationError(exc.errors())
+
+    if payload.agent_uuid != agent.agent_uuid:
+        raise HTTPException(
+            status_code=409,
+            detail="Payload agent_uuid does not match the authenticated agent",
+        )
+
+    checkin, raw_import, policy_response, summary = await _ingest_agent_payload(
+        db=db,
+        agent=agent,
+        payload=payload,
+        decoded_body=decoded_body,
+        content_encoding=request.headers.get("content-encoding"),
+        source_ip=request.client.host if request.client else None,
+    )
+    await db.commit()
+    await db.refresh(agent)
+    await db.refresh(checkin)
+    await db.refresh(raw_import)
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id] if agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id] if agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="CHECKIN",
+        actor=f"agent:{agent.agent_uuid}",
+        resource="Agent",
+        resource_id=str(agent.id),
+        status="success",
+        details={
+            "raw_import_id": raw_import.id,
+            "records_created": checkin.records_created,
+        },
+    )
+
+    return AgentCheckInResponse(
+        status="accepted",
+        server_time=_utcnow(),
+        agent=_agent_response(agent),
+        policy=policy_response,
+        checkin=AgentCheckInRecordResponse.model_validate(checkin),
+        summary=summary,
+    )
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+async def get_agent(
+    agent_id: int,
+    user: User = Depends(require_any_authenticated),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _get_agent_or_404(db, agent_id)
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id] if agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id] if agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+    return _agent_response(agent)
+
+
+@router.patch("/{agent_id}", response_model=AgentResponse)
+async def update_agent(
+    agent_id: int,
+    agent_update: AgentUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _get_agent_or_404(db, agent_id)
+    update_data = agent_update.model_dump(exclude_unset=True)
+
+    if "policy_id" in update_data and update_data["policy_id"] is not None:
+        await _get_policy_or_404(db, update_data["policy_id"])
+    if "enrollment_key_id" in update_data and update_data["enrollment_key_id"] is not None:
+        await _get_enrollment_key_or_404(db, update_data["enrollment_key_id"])
+
+    for field, value in update_data.items():
+        setattr(agent, field, value)
+
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Agent UUID already exists")
+
+    await db.refresh(agent)
+    policy_map = await _load_policy_map(
+        db,
+        [agent.policy_id] if agent.policy_id else [],
+    )
+    enrollment_key_map = await _load_enrollment_key_map(
+        db,
+        [agent.enrollment_key_id] if agent.enrollment_key_id else [],
+    )
+    default_policy_map = await _load_policy_map(
+        db,
+        [
+            enrollment_key.default_policy_id
+            for enrollment_key in enrollment_key_map.values()
+            if enrollment_key.default_policy_id
+        ],
+    )
+    policy_map.update(default_policy_map)
+    await _attach_key_and_policy(agent, policy_map, enrollment_key_map)
+
+    audit.log(
+        action="UPDATE",
+        actor="user",
+        resource="Agent",
+        resource_id=str(agent.id),
+        status="success",
+        details={"agent_uuid": agent.agent_uuid},
+    )
+    return _agent_response(agent)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -15,7 +15,7 @@ nmap returns device_type="wireless_ap", netstat returns state="LISTEN").
 """
 
 from datetime import datetime
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 from ipaddress import ip_address as parse_ip
 import re
 
@@ -61,12 +61,31 @@ VALID_CONNECTION_STATES = frozenset({
 })
 
 VALID_SOURCE_TYPES = frozenset({
-    "nmap", "arp", "netstat", "ping", "traceroute", "pcap", "manual",
+    "nmap", "arp", "netstat", "ping", "traceroute", "pcap", "manual", "agent",
 })
 
 VALID_IMPORT_TYPES = frozenset({
     "xml", "grep", "json", "text", "csv", "pcap", "raw",
-    "file", "paste",  # set by the import endpoints themselves
+    "file", "paste", "agent",  # set by the import endpoints themselves
+})
+
+VALID_AGENT_COMMANDS = frozenset({
+    "ip_neigh",
+    "ss_tunap",
+    "ip_addr",
+    "ip_route",
+})
+
+VALID_AGENT_ENROLLMENT_STATES = frozenset({
+    "pending",
+    "active",
+    "rejected",
+    "revoked",
+})
+
+VALID_AGENT_CHECKIN_STATUSES = frozenset({
+    "accepted",
+    "rejected",
 })
 
 # ── Reusable validators ──────────────────────────────────────────────
@@ -725,6 +744,400 @@ class LinkHostsRequest(BaseModel):
     """Schema for linking hosts to a device identity."""
 
     host_ids: List[int]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# AGENT SCHEMAS
+# ═══════════════════════════════════════════════════════════════════════
+
+DEFAULT_AGENT_COMMAND_SET = {
+    "ip_neigh": True,
+    "ss_tunap": True,
+    "ip_addr": True,
+    "ip_route": True,
+}
+
+
+class AgentPolicyFields(BaseModel):
+    """Low-impact passive collection policy distributed to agents."""
+
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=4000)
+    checkin_interval_seconds: int = Field(3600, ge=60, le=86400)
+    jitter_seconds: int = Field(300, ge=0, le=3600)
+    command_timeout_seconds: int = Field(15, ge=1, le=300)
+    enabled_commands: Dict[str, bool] = Field(
+        default_factory=lambda: DEFAULT_AGENT_COMMAND_SET.copy()
+    )
+    max_report_bytes: int = Field(262144, ge=16384, le=10 * 1024 * 1024)
+    is_active: bool = True
+
+
+class _AgentPolicyValidators:
+    @field_validator("enabled_commands")
+    @classmethod
+    def validate_enabled_commands(cls, value: Dict[str, bool]) -> Dict[str, bool]:
+        unexpected = sorted(set(value.keys()) - VALID_AGENT_COMMANDS)
+        if unexpected:
+            raise ValueError(
+                f"Invalid agent commands: {', '.join(unexpected)}. "
+                f"Allowed values: {', '.join(sorted(VALID_AGENT_COMMANDS))}"
+            )
+        return value
+
+
+class AgentPolicyCreate(AgentPolicyFields, _AgentPolicyValidators):
+    """Schema for creating an agent policy."""
+
+
+class AgentPolicyUpdate(BaseModel, _AgentPolicyValidators):
+    """Schema for updating an agent policy."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=4000)
+    checkin_interval_seconds: Optional[int] = Field(None, ge=60, le=86400)
+    jitter_seconds: Optional[int] = Field(None, ge=0, le=3600)
+    command_timeout_seconds: Optional[int] = Field(None, ge=1, le=300)
+    enabled_commands: Optional[Dict[str, bool]] = None
+    max_report_bytes: Optional[int] = Field(None, ge=16384, le=10 * 1024 * 1024)
+    is_active: Optional[bool] = None
+
+
+class AgentPolicyResponse(AgentPolicyFields):
+    """Schema for agent policy responses."""
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+    agent_count: Optional[int] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentEnrollmentKeyFields(BaseModel):
+    """Admin-managed bootstrap key for enrolling one or more agents."""
+
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=4000)
+    default_policy_id: Optional[int] = None
+    auto_approve: bool = False
+    is_active: bool = True
+    expires_at: Optional[datetime] = None
+    max_registrations: Optional[int] = Field(None, ge=1, le=100000)
+
+
+class AgentEnrollmentKeyCreate(AgentEnrollmentKeyFields):
+    """Schema for creating an enrollment key."""
+
+
+class AgentEnrollmentKeyUpdate(BaseModel):
+    """Schema for updating an enrollment key."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=4000)
+    default_policy_id: Optional[int] = None
+    auto_approve: Optional[bool] = None
+    is_active: Optional[bool] = None
+    expires_at: Optional[datetime] = None
+    max_registrations: Optional[int] = Field(None, ge=1, le=100000)
+
+
+class AgentEnrollmentKeyResponse(AgentEnrollmentKeyFields):
+    """Schema for enrollment key responses."""
+
+    id: int
+    key_prefix: str
+    registration_count: int
+    created_at: datetime
+    updated_at: datetime
+    last_used_at: Optional[datetime] = None
+    default_policy: Optional[AgentPolicyResponse] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentEnrollmentKeyCreateResponse(BaseModel):
+    """Schema returned when a new enrollment key is created."""
+
+    enrollment_key: str
+    key: AgentEnrollmentKeyResponse
+
+
+class AgentFields(BaseModel):
+    """Registry metadata for a passive agent."""
+
+    agent_uuid: str = Field(..., min_length=1, max_length=128)
+    display_name: Optional[str] = Field(None, max_length=255)
+    hostname: Optional[str] = Field(None, max_length=255)
+    site_name: Optional[str] = Field(None, max_length=255)
+    enrollment_key_id: Optional[int] = None
+    policy_id: Optional[int] = None
+    enrollment_state: str = Field("pending", max_length=20)
+    approval_required: bool = True
+    agent_version: Optional[str] = Field(None, max_length=100)
+    platform: Optional[str] = Field(None, max_length=255)
+    platform_release: Optional[str] = Field(None, max_length=255)
+    is_active: bool = True
+
+
+class _AgentValidators:
+    @field_validator("enrollment_state")
+    @classmethod
+    def validate_enrollment_state(cls, value: str) -> str:
+        lower = value.lower()
+        if lower not in VALID_AGENT_ENROLLMENT_STATES:
+            raise ValueError(
+                f"Invalid enrollment state '{value}'. "
+                f"Allowed values: {', '.join(sorted(VALID_AGENT_ENROLLMENT_STATES))}"
+            )
+        return lower
+
+
+class AgentCreate(AgentFields, _AgentValidators):
+    """Schema for creating an enrolled agent."""
+
+
+class AgentUpdate(BaseModel, _AgentValidators):
+    """Schema for updating an enrolled agent."""
+
+    display_name: Optional[str] = Field(None, max_length=255)
+    hostname: Optional[str] = Field(None, max_length=255)
+    site_name: Optional[str] = Field(None, max_length=255)
+    enrollment_key_id: Optional[int] = None
+    policy_id: Optional[int] = None
+    enrollment_state: Optional[str] = Field(None, max_length=20)
+    approval_required: Optional[bool] = None
+    agent_version: Optional[str] = Field(None, max_length=100)
+    platform: Optional[str] = Field(None, max_length=255)
+    platform_release: Optional[str] = Field(None, max_length=255)
+    is_active: Optional[bool] = None
+
+
+class AgentResponse(AgentFields):
+    """Schema for agent registry responses."""
+
+    id: int
+    api_key_prefix: Optional[str] = None
+    approved_at: Optional[datetime] = None
+    rejected_at: Optional[datetime] = None
+    api_key_issued_at: Optional[datetime] = None
+    last_registration_at: Optional[datetime] = None
+    last_ip_addresses: Optional[List[str]] = None
+    last_mac_addresses: Optional[List[str]] = None
+    last_registration_summary: Optional[Dict[str, Any]] = None
+    last_checkin_summary: Optional[Dict[str, Any]] = None
+    created_at: datetime
+    updated_at: datetime
+    last_seen_at: Optional[datetime] = None
+    policy: Optional[AgentPolicyResponse] = None
+    enrollment_key: Optional[AgentEnrollmentKeyResponse] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentNeighborObservation(BaseModel):
+    """Single passive neighbor table observation."""
+
+    ip_address: str
+    mac_address: Optional[str] = None
+    interface: Optional[str] = Field(None, max_length=255)
+    state: Optional[str] = Field(None, max_length=50)
+    hostname: Optional[str] = Field(None, max_length=255)
+
+    @field_validator("ip_address")
+    @classmethod
+    def validate_ip(cls, value: str) -> str:
+        return _validate_ip(value, "neighbor IP address")
+
+    @field_validator("mac_address")
+    @classmethod
+    def validate_mac(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return _validate_mac(value)
+
+
+class AgentConnectionObservation(BaseModel):
+    """Single passive connection observation."""
+
+    local_ip: str
+    local_port: int = Field(..., ge=0, le=65535)
+    remote_ip: str
+    remote_port: Optional[int] = Field(None, ge=0, le=65535)
+    protocol: str
+    state: Optional[str] = None
+    pid: Optional[int] = None
+    process_name: Optional[str] = Field(None, max_length=255)
+
+    @field_validator("local_ip")
+    @classmethod
+    def validate_local_ip(cls, value: str) -> str:
+        return _validate_ip(value, "local IP address", allow_unspecified=True)
+
+    @field_validator("remote_ip")
+    @classmethod
+    def validate_remote_ip(cls, value: str) -> str:
+        return _validate_ip(value, "remote IP address", allow_unspecified=True)
+
+    @field_validator("protocol")
+    @classmethod
+    def validate_protocol(cls, value: str) -> str:
+        lower = value.lower()
+        if lower not in VALID_PROTOCOLS:
+            raise ValueError(
+                f"Invalid protocol '{value}'. "
+                f"Allowed values: {', '.join(sorted(VALID_PROTOCOLS))}"
+            )
+        return lower
+
+    @field_validator("state")
+    @classmethod
+    def validate_state(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        lower = value.lower()
+        if lower not in VALID_CONNECTION_STATES:
+            raise ValueError(
+                f"Invalid connection state '{value}'. "
+                f"Allowed values: {', '.join(sorted(VALID_CONNECTION_STATES))}"
+            )
+        return lower
+
+
+class AgentAddressObservation(BaseModel):
+    """Local interface address observation."""
+
+    ip_address: str
+    interface: Optional[str] = Field(None, max_length=255)
+    prefix_length: Optional[int] = Field(None, ge=0, le=128)
+    mac_address: Optional[str] = None
+
+    @field_validator("ip_address")
+    @classmethod
+    def validate_ip(cls, value: str) -> str:
+        return _validate_ip(value, "interface IP address")
+
+    @field_validator("mac_address")
+    @classmethod
+    def validate_mac(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return _validate_mac(value)
+
+
+class AgentRouteObservation(BaseModel):
+    """Local route table observation."""
+
+    destination: str = Field(..., min_length=1, max_length=255)
+    gateway: Optional[str] = None
+    interface: Optional[str] = Field(None, max_length=255)
+    source_ip: Optional[str] = None
+
+    @field_validator("gateway")
+    @classmethod
+    def validate_gateway(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return _validate_ip(value, "route gateway")
+
+    @field_validator("source_ip")
+    @classmethod
+    def validate_source_ip(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return _validate_ip(value, "route source IP")
+
+
+class AgentRegistrationRequest(BaseModel):
+    """Bootstrap request sent by an unenrolled or pending agent."""
+
+    enrollment_key: str = Field(..., min_length=1, max_length=512)
+    agent_uuid: str = Field(..., min_length=1, max_length=128)
+    display_name: Optional[str] = Field(None, max_length=255)
+    hostname: Optional[str] = Field(None, max_length=255)
+    site_name: Optional[str] = Field(None, max_length=255)
+    agent_version: Optional[str] = Field(None, max_length=100)
+    platform: Optional[str] = Field(None, max_length=255)
+    platform_release: Optional[str] = Field(None, max_length=255)
+    metadata: Optional[Dict[str, Any]] = None
+    addresses: List[AgentAddressObservation] = Field(default_factory=list)
+
+
+class AgentRegistrationResponse(BaseModel):
+    """Response returned during enrollment and approval polling."""
+
+    status: str
+    approval_required: bool
+    message: Optional[str] = None
+    api_key: Optional[str] = None
+    server_time: datetime
+    agent: AgentResponse
+    policy: Optional[AgentPolicyResponse] = None
+
+
+class AgentApprovalRequest(BaseModel):
+    """Admin approval or policy assignment for a pending agent."""
+
+    policy_id: Optional[int] = None
+    display_name: Optional[str] = Field(None, max_length=255)
+
+
+class AgentRejectRequest(BaseModel):
+    """Admin rejection metadata for a pending agent."""
+
+    reason: Optional[str] = Field(None, max_length=1000)
+
+
+class AgentCheckInRequest(BaseModel):
+    """Normalized passive report uploaded by a deployed agent."""
+
+    agent_uuid: str = Field(..., min_length=1, max_length=128)
+    observed_at: datetime
+    sequence_number: Optional[int] = Field(None, ge=0)
+    full_snapshot: bool = False
+    hostname: Optional[str] = Field(None, max_length=255)
+    fqdn: Optional[str] = Field(None, max_length=255)
+    agent_version: Optional[str] = Field(None, max_length=100)
+    platform: Optional[str] = Field(None, max_length=255)
+    platform_release: Optional[str] = Field(None, max_length=255)
+    metadata: Optional[Dict[str, Any]] = None
+    neighbors: List[AgentNeighborObservation] = Field(default_factory=list)
+    connections: List[AgentConnectionObservation] = Field(default_factory=list)
+    addresses: List[AgentAddressObservation] = Field(default_factory=list)
+    routes: List[AgentRouteObservation] = Field(default_factory=list)
+
+
+class AgentCheckInRecordResponse(BaseModel):
+    """Serialized audit record for an agent check-in."""
+
+    id: int
+    agent_id: int
+    raw_import_id: Optional[int] = None
+    observed_at: datetime
+    received_at: datetime
+    sequence_number: Optional[int] = None
+    full_snapshot: bool
+    content_encoding: Optional[str] = None
+    source_ip: Optional[str] = None
+    auth_method: Optional[str] = None
+    api_key_prefix: Optional[str] = None
+    summary: Optional[Dict[str, Any]] = None
+    status: str
+    error_message: Optional[str] = None
+    records_created: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentCheckInResponse(BaseModel):
+    """Response returned to an agent after a successful check-in."""
+
+    status: str
+    server_time: datetime
+    agent: AgentResponse
+    policy: Optional[AgentPolicyResponse] = None
+    checkin: AgentCheckInRecordResponse
+    summary: Dict[str, Any]
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,0 +1,299 @@
+import gzip
+import json
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+
+from config import settings
+from database import get_db
+from main import app
+from models import (
+    ARPEntry,
+    Agent,
+    AgentCheckIn,
+    AgentEnrollmentKey,
+    Connection,
+    Host,
+    RawImport,
+)
+
+
+class TestAgentEnrollmentAndCheckIn:
+    @pytest.mark.asyncio
+    async def test_create_enrollment_key_and_pending_registration(
+        self,
+        async_client: AsyncClient,
+        auth_headers,
+    ):
+        headers = await auth_headers("admin", "agent_admin")
+
+        policy_response = await async_client.post(
+            "/api/agents/policies",
+            json={
+                "name": "hourly-passive",
+                "description": "Low impact hourly collection",
+                "checkin_interval_seconds": 3600,
+                "jitter_seconds": 300,
+                "command_timeout_seconds": 20,
+                "enabled_commands": {
+                    "ip_neigh": True,
+                    "ss_tunap": True,
+                    "ip_addr": True,
+                    "ip_route": False,
+                },
+                "max_report_bytes": 262144,
+                "is_active": True,
+            },
+            headers=headers,
+        )
+        assert policy_response.status_code == 201
+        policy_id = policy_response.json()["id"]
+
+        enrollment_response = await async_client.post(
+            "/api/agents/enrollment-keys",
+            json={
+                "name": "branch-offices",
+                "description": "Manual approval required for branch sites",
+                "default_policy_id": policy_id,
+                "auto_approve": False,
+                "is_active": True,
+                "max_registrations": 10,
+            },
+            headers=headers,
+        )
+        assert enrollment_response.status_code == 201
+        enrollment_data = enrollment_response.json()
+        enrollment_key = enrollment_data["enrollment_key"]
+        assert enrollment_data["key"]["default_policy"]["id"] == policy_id
+
+        register_response = await async_client.post(
+            "/api/agents/register",
+            json={
+                "enrollment_key": enrollment_key,
+                "agent_uuid": "agent-001",
+                "display_name": "Branch router",
+                "hostname": "branch-router-01",
+                "site_name": "Boise",
+                "agent_version": "0.1.0",
+                "platform": "linux",
+                "platform_release": "6.12",
+                "addresses": [
+                    {
+                        "ip_address": "10.10.0.5",
+                        "interface": "eth0",
+                        "prefix_length": 24,
+                        "mac_address": "AA:BB:CC:DD:EE:01",
+                    }
+                ],
+            },
+        )
+        assert register_response.status_code == 200
+        register_data = register_response.json()
+        assert register_data["status"] == "pending"
+        assert register_data["approval_required"] is True
+        assert register_data["api_key"] is None
+        assert register_data["agent"]["enrollment_state"] == "pending"
+        assert register_data["agent"]["policy"]["id"] == policy_id
+
+        list_response = await async_client.get("/api/agents", headers=headers)
+        assert list_response.status_code == 200
+        list_data = list_response.json()
+        assert list_data["total"] == 1
+        assert list_data["items"][0]["agent_uuid"] == "agent-001"
+        assert list_data["items"][0]["enrollment_state"] == "pending"
+
+        db_gen = app.dependency_overrides[get_db]()
+        db = await db_gen.__anext__()
+        assert (
+            await db.execute(select(func.count(AgentEnrollmentKey.id)))
+        ).scalar_one() == 1
+
+    @pytest.mark.asyncio
+    async def test_approval_then_api_key_checkin_ingests_and_deduplicates(
+        self,
+        async_client: AsyncClient,
+        auth_headers,
+    ):
+        admin_headers = await auth_headers("admin", "agent_checkin_admin")
+
+        policy_response = await async_client.post(
+            "/api/agents/policies",
+            json={
+                "name": "agent-default",
+                "description": "Default passive check-in policy",
+                "checkin_interval_seconds": 1800,
+                "jitter_seconds": 120,
+                "command_timeout_seconds": 15,
+                "enabled_commands": {
+                    "ip_neigh": True,
+                    "ss_tunap": True,
+                    "ip_addr": True,
+                    "ip_route": True,
+                },
+                "max_report_bytes": 262144,
+                "is_active": True,
+            },
+            headers=admin_headers,
+        )
+        assert policy_response.status_code == 201
+        policy_id = policy_response.json()["id"]
+
+        enrollment_response = await async_client.post(
+            "/api/agents/enrollment-keys",
+            json={
+                "name": "lab-enrollment",
+                "description": "Pending approval for lab agents",
+                "default_policy_id": policy_id,
+                "auto_approve": False,
+                "is_active": True,
+            },
+            headers=admin_headers,
+        )
+        assert enrollment_response.status_code == 201
+        enrollment_key = enrollment_response.json()["enrollment_key"]
+
+        register_payload = {
+            "enrollment_key": enrollment_key,
+            "agent_uuid": "agent-002",
+            "display_name": "Passive collector",
+            "hostname": "collector-01",
+            "site_name": "Lab",
+            "agent_version": "0.1.0",
+            "platform": "linux",
+            "platform_release": "6.12",
+            "metadata": {"collector": "systemd-timer"},
+            "addresses": [
+                {
+                    "ip_address": "10.0.0.5",
+                    "interface": "eth0",
+                    "prefix_length": 24,
+                    "mac_address": "AA:BB:CC:DD:EE:FF",
+                }
+            ],
+        }
+
+        initial_register = await async_client.post(
+            "/api/agents/register",
+            json=register_payload,
+        )
+        assert initial_register.status_code == 200
+        assert initial_register.json()["status"] == "pending"
+        agent_id = initial_register.json()["agent"]["id"]
+
+        approve_response = await async_client.post(
+            f"/api/agents/{agent_id}/approve",
+            json={"policy_id": policy_id},
+            headers=admin_headers,
+        )
+        assert approve_response.status_code == 200
+        assert approve_response.json()["enrollment_state"] == "active"
+
+        approved_register = await async_client.post(
+            "/api/agents/register",
+            json=register_payload,
+        )
+        assert approved_register.status_code == 200
+        approved_data = approved_register.json()
+        assert approved_data["status"] == "active"
+        assert approved_data["approval_required"] is False
+        assert approved_data["api_key"]
+        api_key = approved_data["api_key"]
+
+        base_payload = {
+            "agent_uuid": "agent-002",
+            "observed_at": "2026-03-22T18:00:00Z",
+            "sequence_number": 1,
+            "full_snapshot": False,
+            "hostname": "collector-01",
+            "agent_version": "0.1.0",
+            "platform": "linux",
+            "platform_release": "6.12",
+            "metadata": {"collector": "systemd-timer"},
+            "addresses": [
+                {
+                    "ip_address": "10.0.0.5",
+                    "interface": "eth0",
+                    "prefix_length": 24,
+                    "mac_address": "AA:BB:CC:DD:EE:FF",
+                }
+            ],
+            "neighbors": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "mac_address": "11:22:33:44:55:66",
+                    "interface": "eth0",
+                    "state": "reachable",
+                }
+            ],
+            "connections": [
+                {
+                    "local_ip": "10.0.0.5",
+                    "local_port": 443,
+                    "remote_ip": "10.0.0.10",
+                    "remote_port": 51514,
+                    "protocol": "tcp",
+                    "state": "established",
+                    "pid": 777,
+                    "process_name": "python",
+                }
+            ],
+            "routes": [
+                {
+                    "destination": "default",
+                    "gateway": "10.0.0.1",
+                    "interface": "eth0",
+                    "source_ip": "10.0.0.5",
+                }
+            ],
+        }
+
+        checkin_headers = {
+            settings.AGENT_API_KEY_HEADER: api_key,
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+        }
+
+        first_response = await async_client.post(
+            "/api/agents/check-in",
+            content=gzip.compress(json.dumps(base_payload).encode("utf-8")),
+            headers=checkin_headers,
+        )
+        assert first_response.status_code == 200
+        first_data = first_response.json()
+        assert first_data["status"] == "accepted"
+        assert first_data["summary"]["hosts_created"] == 3
+        assert first_data["summary"]["arp_entries_created"] == 1
+        assert first_data["summary"]["connections_created"] == 1
+        assert first_data["policy"]["id"] == policy_id
+        assert first_data["checkin"]["auth_method"] == "api_key"
+
+        second_payload = dict(base_payload)
+        second_payload["sequence_number"] = 2
+        second_payload["observed_at"] = "2026-03-22T18:30:00Z"
+
+        second_response = await async_client.post(
+            "/api/agents/check-in",
+            content=gzip.compress(json.dumps(second_payload).encode("utf-8")),
+            headers=checkin_headers,
+        )
+        assert second_response.status_code == 200
+        second_data = second_response.json()
+        assert second_data["summary"]["hosts_created"] == 0
+        assert second_data["summary"]["arp_entries_created"] == 0
+        assert second_data["summary"]["connections_created"] == 0
+
+        db_gen = app.dependency_overrides[get_db]()
+        db = await db_gen.__anext__()
+
+        assert (await db.execute(select(func.count(Host.id)))).scalar_one() == 3
+        assert (await db.execute(select(func.count(ARPEntry.id)))).scalar_one() == 1
+        assert (await db.execute(select(func.count(Connection.id)))).scalar_one() == 1
+        assert (await db.execute(select(func.count(RawImport.id)))).scalar_one() == 2
+        assert (await db.execute(select(func.count(AgentCheckIn.id)))).scalar_one() == 2
+
+        result = await db.execute(select(Agent).where(Agent.id == agent_id))
+        agent = result.scalar_one()
+        assert agent.last_seen_at is not None
+        assert agent.api_key_hash is not None
+        assert agent.last_ip_addresses == ["10.0.0.1", "10.0.0.10", "10.0.0.5"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ This folder documents how Graphēon works end-to-end. The codebase standardizes 
 - `docs/backend.md` - Backend architecture, configuration, and API surface.
 - `docs/frontend.md` - Frontend architecture, routing, and component structure.
 - `docs/auth_provider.md` - Authentication providers, OIDC setup, rollout modes, and RBAC.
+- `docs/agents.md` - Passive agent registry, enrollment flow, and API-key-backed ingest model.
+- `docs/agent_quickstart.md` - Step-by-step passive agent bootstrap, approval, and check-in guide.
 - `docs/imports.md` - Import pipeline, parsers, and supported data sources.
 - `docs/tagging-correlation.md` - Tagging rules and correlation behavior.
 - `docs/testing.md` - Test suite, pytest configuration, CI pipeline, and running tests.

--- a/docs/agent_quickstart.md
+++ b/docs/agent_quickstart.md
@@ -1,0 +1,317 @@
+# Agent Quickstart
+
+This guide walks through the current passive-agent MVP using the API surface that exists today.
+
+It covers:
+
+1. Creating a passive collection policy
+2. Creating an enrollment key
+3. Registering a new agent
+4. Approving the agent
+5. Obtaining the per-agent API key
+6. Sending a passive check-in
+
+## Prerequisites
+
+- Graphēon backend running
+- An admin account
+- `curl`
+- `jq`
+- A host where you can persist agent state locally
+
+For local development:
+
+```bash
+nix develop -c bash -lc "cd backend && uvicorn main:app --reload"
+```
+
+## 1. Log In As Admin
+
+Get a JWT from the local admin login endpoint:
+
+```bash
+export GRAPH_URL="http://localhost:8000"
+
+export TOKEN="$(
+  curl -sS \
+    -X POST "$GRAPH_URL/api/auth/login/local" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "username": "admin",
+      "password": "changeme"
+    }' | jq -r '.access_token'
+)"
+```
+
+## 2. Create A Passive Agent Policy
+
+This example keeps the command set small and the cadence gentle:
+
+```bash
+export POLICY_ID="$(
+  curl -sS \
+    -X POST "$GRAPH_URL/api/agents/policies" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "name": "default-passive-hourly",
+      "description": "Hourly passive collection with low impact defaults",
+      "checkin_interval_seconds": 3600,
+      "jitter_seconds": 300,
+      "command_timeout_seconds": 15,
+      "enabled_commands": {
+        "ip_neigh": true,
+        "ss_tunap": true,
+        "ip_addr": true,
+        "ip_route": true
+      },
+      "max_report_bytes": 262144,
+      "is_active": true
+    }' | jq -r '.id'
+)"
+```
+
+## 3. Create An Enrollment Key
+
+This key allows agents to bootstrap into a `pending` state that requires admin approval:
+
+```bash
+ENROLLMENT_JSON="$(
+  curl -sS \
+    -X POST "$GRAPH_URL/api/agents/enrollment-keys" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"name\": \"branch-rollout-1\",
+      \"description\": \"Manual approval for first branch rollout\",
+      \"default_policy_id\": $POLICY_ID,
+      \"auto_approve\": false,
+      \"is_active\": true,
+      \"max_registrations\": 50
+    }"
+)"
+
+export ENROLLMENT_KEY="$(printf '%s' "$ENROLLMENT_JSON" | jq -r '.enrollment_key')"
+```
+
+Important: the raw enrollment key is only returned once. Store it in your secret-management flow.
+
+## 4. Generate And Persist `agent_uuid`
+
+Do this once on the host. Do not derive it from MAC addresses.
+
+```bash
+sudo install -d -m 0700 /var/lib/grapheon-agent
+test -f /var/lib/grapheon-agent/agent_uuid || uuidgen | sudo tee /var/lib/grapheon-agent/agent_uuid >/dev/null
+export AGENT_UUID="$(sudo cat /var/lib/grapheon-agent/agent_uuid)"
+```
+
+## 5. Register The Agent
+
+Send a bootstrap registration request with basic host metadata:
+
+```bash
+REGISTER_JSON="$(
+  curl -sS \
+    -X POST "$GRAPH_URL/api/agents/register" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"enrollment_key\": \"$ENROLLMENT_KEY\",
+      \"agent_uuid\": \"$AGENT_UUID\",
+      \"display_name\": \"Branch Router 01\",
+      \"hostname\": \"branch-router-01\",
+      \"site_name\": \"Boise\",
+      \"agent_version\": \"0.1.0\",
+      \"platform\": \"linux\",
+      \"platform_release\": \"6.12\",
+      \"addresses\": [
+        {
+          \"ip_address\": \"10.20.0.5\",
+          \"interface\": \"eth0\",
+          \"prefix_length\": 24,
+          \"mac_address\": \"AA:BB:CC:DD:EE:01\"
+        }
+      ]
+    }"
+)"
+
+printf '%s\n' "$REGISTER_JSON" | jq
+```
+
+Expected result with `auto_approve=false`:
+
+- `status` is `pending`
+- `approval_required` is `true`
+- no `api_key` is returned yet
+
+## 6. Review And Approve The Agent
+
+List pending agents:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  "$GRAPH_URL/api/agents?enrollment_state=pending" | jq
+```
+
+Approve the agent:
+
+```bash
+export AGENT_ID="$(
+  curl -sS \
+    -H "Authorization: Bearer $TOKEN" \
+    "$GRAPH_URL/api/agents?enrollment_state=pending" | jq -r '.items[0].id'
+)"
+
+curl -sS \
+  -X POST "$GRAPH_URL/api/agents/$AGENT_ID/approve" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"policy_id\": $POLICY_ID
+  }" | jq
+```
+
+## 7. Re-Register To Receive The Per-Agent API Key
+
+After approval, call the same registration endpoint again:
+
+```bash
+REGISTER_ACTIVE_JSON="$(
+  curl -sS \
+    -X POST "$GRAPH_URL/api/agents/register" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"enrollment_key\": \"$ENROLLMENT_KEY\",
+      \"agent_uuid\": \"$AGENT_UUID\",
+      \"display_name\": \"Branch Router 01\",
+      \"hostname\": \"branch-router-01\",
+      \"site_name\": \"Boise\",
+      \"agent_version\": \"0.1.0\",
+      \"platform\": \"linux\",
+      \"platform_release\": \"6.12\",
+      \"addresses\": [
+        {
+          \"ip_address\": \"10.20.0.5\",
+          \"interface\": \"eth0\",
+          \"prefix_length\": 24,
+          \"mac_address\": \"AA:BB:CC:DD:EE:01\"
+        }
+      ]
+    }"
+)"
+
+export AGENT_API_KEY="$(printf '%s' "$REGISTER_ACTIVE_JSON" | jq -r '.api_key')"
+```
+
+Important: the per-agent API key is only returned when it is first issued. Persist it locally on the host, for example:
+
+```bash
+printf '%s\n' "$AGENT_API_KEY" | sudo tee /var/lib/grapheon-agent/api_key >/dev/null
+sudo chmod 0600 /var/lib/grapheon-agent/api_key
+```
+
+## 8. Send A Passive Check-In
+
+The current backend expects a normalized JSON payload. This example sends one manually.
+
+Create a payload:
+
+```bash
+cat >/tmp/grapheon-agent-report.json <<EOF
+{
+  "agent_uuid": "$AGENT_UUID",
+  "observed_at": "2026-03-22T18:00:00Z",
+  "sequence_number": 1,
+  "full_snapshot": false,
+  "hostname": "branch-router-01",
+  "agent_version": "0.1.0",
+  "platform": "linux",
+  "platform_release": "6.12",
+  "metadata": {
+    "collector": "manual-quickstart"
+  },
+  "addresses": [
+    {
+      "ip_address": "10.20.0.5",
+      "interface": "eth0",
+      "prefix_length": 24,
+      "mac_address": "AA:BB:CC:DD:EE:01"
+    }
+  ],
+  "neighbors": [
+    {
+      "ip_address": "10.20.0.1",
+      "mac_address": "11:22:33:44:55:66",
+      "interface": "eth0",
+      "state": "reachable"
+    }
+  ],
+  "connections": [
+    {
+      "local_ip": "10.20.0.5",
+      "local_port": 443,
+      "remote_ip": "10.20.0.10",
+      "remote_port": 51514,
+      "protocol": "tcp",
+      "state": "established",
+      "pid": 777,
+      "process_name": "python"
+    }
+  ],
+  "routes": [
+    {
+      "destination": "default",
+      "gateway": "10.20.0.1",
+      "interface": "eth0",
+      "source_ip": "10.20.0.5"
+    }
+  ]
+}
+EOF
+```
+
+Send it with gzip compression:
+
+```bash
+gzip -c /tmp/grapheon-agent-report.json >/tmp/grapheon-agent-report.json.gz
+
+curl -sS \
+  -X POST "$GRAPH_URL/api/agents/check-in" \
+  -H "Content-Type: application/json" \
+  -H "Content-Encoding: gzip" \
+  -H "X-Agent-Api-Key: $AGENT_API_KEY" \
+  --data-binary @/tmp/grapheon-agent-report.json.gz | jq
+```
+
+Expected result:
+
+- `status` is `accepted`
+- `summary.hosts_created`, `summary.arp_entries_created`, and `summary.connections_created` reflect the ingest result
+- the response includes the resolved policy and check-in audit metadata
+
+## 9. Verify In The Admin API
+
+List the agent:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  "$GRAPH_URL/api/agents/$AGENT_ID" | jq
+```
+
+List check-ins:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  "$GRAPH_URL/api/agents/$AGENT_ID/checkins" | jq
+```
+
+## Operational Notes
+
+- Keep `agent_uuid` and the per-agent API key on disk with restrictive permissions.
+- Treat the enrollment key as a bootstrap secret only.
+- Prefer `auto_approve=false` for real rollouts.
+- Do not run active scanning commands in the agent MVP.
+- A future packaged agent can replace the manual JSON payload with normalized output from local commands.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,142 @@
+# Passive Agents
+
+Graphēon now has the backend foundation for a low-impact passive agent fleet. The MVP stays intentionally conservative: outbound-only check-in, no active scanning, slow cadence, and reuse of Graphēon's existing host, ARP, connection, and import models.
+
+For a concrete API walkthrough, see `docs/agent_quickstart.md`.
+
+## MVP Shape
+
+- Runtime model: one-shot collector plus `systemd` timer on the managed host.
+- Collection model: local/passive commands only such as `ip neigh`, `ss -tunap`, `ip addr`, and `ip route`.
+- Transport model: compressed JSON reports over HTTPS with outbound-only check-in.
+- Backend model: agent registry, enrollment keys, approval workflow, policy profiles, check-in audit records, and normalized ingest into existing Graphēon tables.
+
+## Identity Model
+
+Use two separate values:
+
+- `agent_uuid`: random, generated once by the agent on first run and persisted locally
+- API keys: opaque shared secrets used only for authentication
+
+Do not derive `agent_uuid` from MAC addresses or other host traits. MACs are operational metadata and can change or be duplicated. `agent_uuid` should be stable independent of NIC replacement, VM cloning cleanup, or interface layout.
+
+## Current Backend Endpoints
+
+- `GET /api/agents` - List enrolled agents and last-seen state.
+- `POST /api/agents` - Create an agent record manually as an admin.
+- `GET /api/agents/{id}` - Get one enrolled agent.
+- `PATCH /api/agents/{id}` - Update agent registry metadata or policy assignment.
+- `POST /api/agents/{id}/approve` - Approve a pending agent.
+- `POST /api/agents/{id}/reject` - Reject a pending agent.
+- `GET /api/agents/{id}/checkins` - List check-in history for one agent.
+- `GET /api/agents/policies` - List passive collection policies.
+- `POST /api/agents/policies` - Create a passive collection policy.
+- `PATCH /api/agents/policies/{id}` - Update a passive collection policy.
+- `GET /api/agents/enrollment-keys` - List enrollment keys.
+- `POST /api/agents/enrollment-keys` - Create an enrollment key and return the secret once.
+- `PATCH /api/agents/enrollment-keys/{id}` - Update an enrollment key.
+- `POST /api/agents/register` - Bootstrap or re-poll agent registration with an enrollment key.
+- `POST /api/agents/check-in` - Agent report ingest endpoint using the per-agent API key.
+
+Read endpoints use the existing viewer/editor/admin auth model. Enrollment-key and check-in endpoints are for machine-to-machine traffic.
+
+## Enrollment Flow
+
+The current MVP enrollment flow is:
+
+1. An admin creates an enrollment key in the UI or API.
+2. The agent generates and stores a random `agent_uuid` locally.
+3. The agent calls `POST /api/agents/register` with:
+   - the enrollment key
+   - `agent_uuid`
+   - hostname, platform, version
+   - local interface IP/MAC summary
+4. The backend creates or updates an agent record.
+5. If the enrollment key has `auto_approve=false`, the agent remains `pending` until an admin approves it in the UI.
+6. Once approved, the agent re-calls `POST /api/agents/register`.
+7. The backend returns a one-time per-agent API key.
+8. The agent stores that per-agent API key and uses it for future `POST /api/agents/check-in` calls.
+
+This keeps bootstrap easy for operators while avoiding a single long-lived fleet-wide shared secret for steady-state operation.
+
+## Enrollment Key Model
+
+Each enrollment key supports:
+
+- `name`
+- `description`
+- `default_policy_id`
+- `auto_approve`
+- `is_active`
+- `expires_at`
+- `max_registrations`
+- `registration_count`
+
+Recommended default is `auto_approve=false` unless you fully trust the environment where the key will be deployed.
+
+## Policy Model
+
+Each policy captures low-impact collection controls:
+
+- `checkin_interval_seconds`
+- `jitter_seconds`
+- `command_timeout_seconds`
+- `enabled_commands`
+- `max_report_bytes`
+
+The command set is explicitly limited in the MVP:
+
+- `ip_neigh`
+- `ss_tunap`
+- `ip_addr`
+- `ip_route`
+
+This keeps the agent side easy to reason about and avoids unexpected CPU or network load.
+
+## Report Model
+
+The ingest endpoint currently expects a normalized JSON payload. That keeps server-side ingest useful before Graphēon ships a packaged collector that converts raw command output into a stable schema.
+
+The payload includes:
+
+- Agent identity and sequence metadata
+- Local interface addresses
+- Neighbor observations
+- Local socket observations
+- Route observations
+- Optional host/platform metadata
+
+Reports may be sent with `Content-Encoding: gzip`. The backend stores the normalized payload in both:
+
+- `agent_checkins` for operational history
+- `raw_imports` for auditability and future replay/converter work
+
+The ingest path upserts:
+
+- `hosts`
+- `arp_entries`
+- `connections`
+
+No automatic correlation run is triggered on every check-in in the MVP. That keeps steady-state ingest cheap. Operators can still run the existing correlation workflow separately.
+
+## Authentication Notes
+
+- Enrollment keys are admin-created bootstrap secrets.
+- Enrollment keys are stored hashed server-side.
+- Per-agent API keys are distinct from enrollment keys.
+- Per-agent API keys are stored hashed server-side.
+- `agent_uuid` is the durable agent identity.
+- API keys authenticate the caller but do not define identity.
+
+The backend verifies:
+
+1. The presented agent API key matches an approved agent record.
+2. The report `agent_uuid` matches that authenticated agent.
+
+## What This Slice Does Not Yet Do
+
+- Package or ship the actual host-side collector/service
+- Parse raw `ip neigh` or `ss` output on the server
+- Rotate per-agent API keys through the agent protocol
+- Surface fleet views in the frontend
+- Issue client certificates or require mTLS for agents

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Graphēon is a FastAPI backend with a React frontend, deployed as two Docker containers. It ingests multiple network data formats, normalizes them into a common schema, tags entities, and correlates them into a graph-like model. The repo standardizes on Python 3.12.
+Graphēon is a FastAPI backend with a React frontend, deployed as two Docker containers. It ingests multiple network data formats, normalizes them into a common schema, tags entities, and correlates them into a graph-like model. The repo standardizes on Python 3.12. It also now includes the backend foundations for outbound-only passive agents that report local observations back to the API.
 
 ## System Overview
 
@@ -14,6 +14,7 @@ graph TB
     subgraph "Backend Container (uvicorn:8000)"
         API[FastAPI Application]
         PARSERS[Parser Registry<br/>nmap / netstat / arp<br/>ping / traceroute / pcap]
+        AGENTS[Passive Agent APIs<br/>registry / policy / check-in]
         CORRELATION[Correlation Engine]
         AUTH[Auth System<br/>JWT + OIDC]
         DB[(SQLite<br/>network.db)]
@@ -23,6 +24,7 @@ graph TB
     NGINX -->|/api/*| API
     NGINX -->|static assets| UI
     API --> PARSERS
+    API --> AGENTS
     API --> CORRELATION
     API --> AUTH
     API --> DB
@@ -94,6 +96,15 @@ flowchart TD
 3. The import pipeline upserts hosts and related records, and assigns tags (IP, MAC, port, service, subnet).
 4. Correlation merges related hosts using IP matching, MAC-based device identity, and tag similarity while guarding against conflicting MACs.
 5. The frontend queries `/api/*` endpoints to render dashboards, tables, and the network graph.
+
+Passive agents follow a parallel path:
+
+1. A lightweight one-shot collector runs locally on a managed host and gathers passive observations from local commands such as `ip neigh`, `ss -tunap`, `ip addr`, and `ip route`.
+2. The agent registers outbound with `POST /api/agents/register` using an admin-created enrollment key plus a locally persisted random `agent_uuid`.
+3. An admin can review the pending record in the UI and approve it.
+4. Once approved, the agent receives a per-agent API key and uses it for `POST /api/agents/check-in`.
+5. The backend stores the report in `agent_checkins` and `raw_imports`, and upserts `hosts`, `arp_entries`, and `connections`.
+6. Existing correlation and graph APIs can then operate on the newly ingested passive data.
 
 ## Request Lifecycle
 


### PR DESCRIPTION
## Summary

This PR adds the first deployable passive-agent backend slice for Graphēon.

The agent bootstrap path now uses:
- admin-created enrollment keys
- optional approval in the agent registry
- one per-agent API key for steady-state check-ins

The backend keeps the MVP intentionally low-impact:
- outbound-only check-in
- no active scanning
- normalized passive report ingest only
- reuse of existing host, ARP, connection, and raw import models

## What Changed

### Backend models and persistence

Added new persistence for passive-agent fleet management:
- `agent_policies`
- `agents`
- `agent_checkins`
- `agent_enrollment_keys`

Updated SQLite startup migrations to add the new agent auth and approval fields and indexes.

### Agent policy and registry API

Added admin/view endpoints for:
- listing and managing passive collection policies
- listing and managing agent registry records
- viewing per-agent check-in history
- creating and managing enrollment keys

### Enrollment and approval flow

Added:
- `POST /api/agents/register`
- `POST /api/agents/{id}/approve`
- `POST /api/agents/{id}/reject`

Flow:
1. Admin creates an enrollment key
2. Agent generates and persists a random `agent_uuid`
3. Agent registers with the enrollment key
4. Backend creates a pending agent record unless auto-approve is enabled
5. Admin approves the pending agent
6. Agent re-registers and receives a one-time per-agent API key
7. Agent uses that API key for future check-ins

### Passive ingest path

Added `POST /api/agents/check-in` using the per-agent API key header.

The ingest path:
- accepts normalized JSON reports, optionally gzip-compressed
- validates that the authenticated agent matches `agent_uuid`
- stores audit history in `agent_checkins`
- stores replay/audit payloads in `raw_imports`
- upserts `hosts`, `arp_entries`, and `connections`

### Documentation

Updated agent documentation to reflect the API-key enrollment model and explicitly reject MAC-derived identity.

Added a new quickstart guide showing the full current workflow using the API:
- create policy
- create enrollment key
- register agent
- approve agent
- retrieve API key
- send passive check-in

## Key Decisions

### `agent_uuid` is not derived from MAC

`agent_uuid` is now treated as a durable random identifier generated once by the agent and persisted locally.

Reasoning:
- MAC-derived identity is brittle
- hosts can have multiple MACs
- virtualized environments can clone or change interfaces
- identity should not rotate because hardware metadata changed

MACs are still collected as metadata, not used as identity.

### Enrollment key != long-term agent credential

Enrollment keys are bootstrap credentials only.

After approval, each agent gets its own API key. This avoids using one shared fleet-wide secret for steady-state traffic and gives us a clean path for per-agent revocation and later rotation.

### Keep ingest cheap

Check-ins do not automatically trigger a full correlation run. The backend only:
- records the check-in
- writes normalized passive observations
- leaves correlation as an explicit operator action

That keeps routine agent traffic lightweight.

## Files Of Interest

- `backend/routers/agents.py`
- `backend/models/agent.py`
- `backend/models/agent_enrollment_key.py`
- `backend/models/agent_checkin.py`
- `backend/models/agent_policy.py`
- `backend/schemas.py`
- `backend/database.py`
- `docs/agents.md`
- `docs/agent_quickstart.md`

## Testing

Attempted:
- `nix develop -c .venv/bin/python -m pytest`

Result:
- blocked during test collection by an environment issue before the test suite could run
- SQLAlchemy async engine initialization fails because `greenlet` cannot load `libstdc++.so.6`

Verified instead:
- `nix develop -c .venv/bin/python -m py_compile ...` on the touched backend files

## Follow-Up Work

### #48
- build the actual host-side collector
- package the one-shot runner and `systemd` timer
- persist `agent_uuid` and issued API key on disk

### #49
- add frontend UI for enrollment-key creation
- add pending-agent approval/rejection UI
- add fleet visibility and operational status views
- add API-key rotation workflow

### #50
- optional later hardening path if we still want mTLS
- can be implemented as a future replacement or enhancement to API-key auth rather than part of the MVP bootstrap flow
