### PR TITLE
Stabilize map view props

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 Versioning policy: do not use `Unreleased` changelog sections. Every behavior change, bug fix, hardening change, or notable test addition must be recorded under a concrete SemVer version. Bump patch versions for bug fixes and minor versions for new behavior or API/UI changes.
 
+## 0.11.1 - 2026-06-11
+### Fixed
+- **Map view stability**: memoized map element merging and callback props so parent re-renders no longer recreate the Cytoscape view and reset pan/zoom.
+
 ## 0.11.0 - 2026-06-11
 ### Added
 - **Passive agent lifecycle actions**: the admin Agents page now exposes explicit revoke and reactivate actions, and shows record active/inactive status as read-only lifecycle state.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grapheon-frontend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grapheon-frontend",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@isoflow/isopacks": "^0.0.10",
         "cytoscape": "^3.33.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grapheon-frontend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/Map.jsx
+++ b/frontend/src/pages/Map.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import CytoscapeNetworkMap from '../components/CytoscapeNetworkMap'
 import IsoflowNetworkMap from '../components/IsoflowNetworkMap'
 import MapErrorBoundary from '../components/MapErrorBoundary'
@@ -113,7 +113,7 @@ export default function Map() {
   }, [showRoutes])
 
   // ── Merge route edges into elements ─────────────────────────────
-  const mergedElements = (() => {
+  const mergedElements = useMemo(() => {
     if (!showRoutes || !routeData.path_edges || routeData.path_edges.length === 0) {
       return elements
     }
@@ -150,7 +150,7 @@ export default function Map() {
       nodes: elements.nodes,
       edges: [...(elements.edges || []), ...routeEdges],
     }
-  })()
+  }, [elements, routeData.path_edges, showRoutes])
 
   // ── Client-side filter handlers ─────────────────────────────────
   const handleSearch = (query) => {
@@ -184,9 +184,11 @@ export default function Map() {
     }
   }
 
-  const handleCyReady = (cy) => {
+  const handleNodeClick = useCallback(() => {}, [])
+
+  const handleCyReady = useCallback((cy) => {
     cyRef.current = cy
-  }
+  }, [])
 
   const handleRefresh = () => {
     fetchNetworkMap()
@@ -464,7 +466,7 @@ export default function Map() {
               <CytoscapeNetworkMap
                 elements={mergedElements}
                 layoutMode={layoutMode}
-                onNodeClick={() => {}}
+                onNodeClick={handleNodeClick}
                 onCyReady={handleCyReady}
                 loading={loading}
               />


### PR DESCRIPTION
## Problem

The map view could flash every few seconds and reset back to the default viewport. The likely trigger was ordinary parent re-renders in `Map.jsx`: even when the underlying topology data had not changed, the page recreated values that are passed into `CytoscapeNetworkMap`.

`CytoscapeNetworkMap` rebuilds its Cytoscape instance from an `initCytoscape` callback whose dependencies include `elements`, `onNodeClick`, and `onCyReady`. When those prop references changed on each render, the lifecycle effect destroyed and recreated the graph, which caused pan/zoom/layout state to snap back to the initial view.

## Changes

- Memoizes `mergedElements` in `frontend/src/pages/Map.jsx` with `useMemo`.
  - When routes are hidden or unchanged, the graph receives the same `elements` object reference instead of a newly allocated wrapper on every render.
  - Route overlay edge merging still recomputes when `elements`, `routeData.path_edges`, or `showRoutes` changes.
- Stabilizes callback props passed to `CytoscapeNetworkMap`.
  - Replaces inline `onNodeClick={() => {}}` with a `useCallback` handler.
  - Wraps `handleCyReady` in `useCallback` so the Cytoscape ready callback does not change identity on unrelated renders.
- Preserves the existing explicit refresh/layout behavior.
  - User-initiated refreshes and real topology/filter changes can still update the map.
  - This only prevents avoidable Cytoscape teardown/recreate cycles caused by referential churn.
- Bumps the frontend patch release to `0.11.1`.
- Adds a dated `frontend/CHANGELOG.md` entry under `0.11.1`; no `Unreleased` section is used.

## Files

- `frontend/src/pages/Map.jsx`
- `frontend/CHANGELOG.md`
- `frontend/package.json`
- `frontend/package-lock.json`

## Validation

- `nix develop -c .venv/bin/python scripts/validate_versions.py`
  - Passed: version files and changelogs are in sync.
- `nix develop -c npm --prefix frontend test`
  - Passed: 37 frontend tests.
- `nix develop -c npm --prefix frontend run build`
  - Passed. Vite still reports the pre-existing large chunk warning.
- `nix develop -c .venv/bin/python -m pytest`
  - Passed: 374 passed, 1 skipped.

## Release Notes

Frontend patch release: `0.11.1`

Fixed map view stability by memoizing graph payload/callback props so unrelated page re-renders no longer recreate the Cytoscape instance and reset the viewport.

## Notes

This applies the previously stashed map-view stability fix from `stash@{0}`. The stash was left in place intentionally after applying and committing it.